### PR TITLE
Validate part vs set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "1.1.1",
+  "version": "1.2.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/melinda-record-match-validator",
-      "version": "1.1.1",
+      "version": "1.2.0-alpha.1",
       "license": "LGPL-3.0+",
       "dependencies": {
         "@natlibfi/marc-record": "^7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/melinda-record-match-validator",
-      "version": "1.2.0-alpha.1",
+      "version": "1.2.0-alpha.2",
       "license": "LGPL-3.0+",
       "dependencies": {
         "@natlibfi/marc-record": "^7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@babel/cli": "^7.19.3",
         "@babel/core": "^7.19.6",
         "@babel/eslint-parser": "^7.19.1",
-        "@babel/node": "^7.19.1",
+        "@babel/node": "^7.20.0",
         "@babel/preset-env": "^7.19.4",
         "@babel/register": "^7.18.9",
         "@natlibfi/eslint-config-melinda-backend": "^2.0.1",
@@ -510,16 +510,16 @@
       }
     },
     "node_modules/@babel/node": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.19.1.tgz",
-      "integrity": "sha512-gfxJNrawPso6kx7SwKfAdX1rEzVc09speJLFKrdxuZXGlve92pjbB3nJVmuwrxNN4+jvytj2zvliNXuW6uaSOw==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.20.0.tgz",
+      "integrity": "sha512-FEWKq7XC2I4ci05L46B9ghJVZc5mkqx1UKtxed0BUq7jaw+8HbpwjF4nsE7I5A4iolIWlMXycGRal1CcAe0PZA==",
       "dev": true,
       "dependencies": {
         "@babel/register": "^7.18.9",
         "commander": "^4.0.1",
         "core-js": "^3.25.1",
         "node-environment-flags": "^1.0.5",
-        "regenerator-runtime": "^0.13.4",
+        "regenerator-runtime": "^0.13.10",
         "v8flags": "^3.1.1"
       },
       "bin": {
@@ -5732,9 +5732,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
       "dev": true
     },
     "node_modules/regenerator-transform": {
@@ -7042,16 +7042,16 @@
       }
     },
     "@babel/node": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.19.1.tgz",
-      "integrity": "sha512-gfxJNrawPso6kx7SwKfAdX1rEzVc09speJLFKrdxuZXGlve92pjbB3nJVmuwrxNN4+jvytj2zvliNXuW6uaSOw==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.20.0.tgz",
+      "integrity": "sha512-FEWKq7XC2I4ci05L46B9ghJVZc5mkqx1UKtxed0BUq7jaw+8HbpwjF4nsE7I5A4iolIWlMXycGRal1CcAe0PZA==",
       "dev": true,
       "requires": {
         "@babel/register": "^7.18.9",
         "commander": "^4.0.1",
         "core-js": "^3.25.1",
         "node-environment-flags": "^1.0.5",
-        "regenerator-runtime": "^0.13.4",
+        "regenerator-runtime": "^0.13.10",
         "v8flags": "^3.1.1"
       }
     },
@@ -10769,9 +10769,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
       "dev": true
     },
     "regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.6",
     "@babel/eslint-parser": "^7.19.1",
-    "@babel/node": "^7.19.1",
+    "@babel/node": "^7.20.0",
     "@babel/preset-env": "^7.19.4",
     "@babel/register": "^7.18.9",
     "@natlibfi/eslint-config-melinda-backend": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "1.1.1",
+  "version": "1.2.0-alpha.1",
   "description": "Validates if two records matched by melinda-record-matching can be merged and sets merge priority",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "description": "Validates if two records matched by melinda-record-matching can be merged and sets merge priority",
   "main": "dist/index.js",
   "repository": {

--- a/src/collectFunctions/collectUtils.js
+++ b/src/collectFunctions/collectUtils.js
@@ -62,3 +62,8 @@ export function getSubfieldValues(field, subfieldCode) {
   }
   return field.subfields.filter(sub => sub.code === subfieldCode).map(sub => sub.value);
 }
+
+export function stripPunc(value) {
+  return value.replace(/(?: [=;:/]|[.,])$/u, '');
+
+}

--- a/src/field245.js
+++ b/src/field245.js
@@ -46,6 +46,7 @@ export function get245(record) {
   function f245ToJSON(field) {
     const title = stripPunc(getSubfield(field, 'a'));
     const remainderOfTitle = stripPunc(getSubfield(field, 'b')); // Do we want
+    // Note: both $p and $n are repeatable, do we get only first(?) instances of them here?
     const numberOfPartInSectionOfAWork = stripPunc(getSubfield(field, 'n'));
     const nameOfPartInSectionOfAWork = stripPunc(getSubfield(field, 'p'));
 

--- a/src/field245.js
+++ b/src/field245.js
@@ -28,7 +28,7 @@
 
 import createDebugLogger from 'debug';
 //import {nvdebug} from '../utils';
-import {hasFields, getSubfield} from './collectFunctions/collectUtils';
+import {hasFields, getSubfield, stripPunc} from './collectFunctions/collectUtils';
 import {compareValueContent} from './compareFunctions/compareUtils';
 //import {fieldGetNonRepeatableValue, fieldToString, nvdebug, subfieldSetsAreEqual} from './utils';
 
@@ -50,11 +50,6 @@ export function get245(record) {
     const nameOfPartInSectionOfAWork = stripPunc(getSubfield(field, 'p'));
 
     return {title, remainderOfTitle, numberOfPartInSectionOfAWork, nameOfPartInSectionOfAWork};
-  }
-
-  function stripPunc(value) {
-    return value.replace(/(?: [=;:/]|[.,])$/u, '');
-
   }
 }
 

--- a/src/fieldSID.js
+++ b/src/fieldSID.js
@@ -61,6 +61,7 @@ function compareSIDValues(SIDsA, SIDsB) {
 
   return compareSIDContent();
 
+  // eslint-disable-next-line max-statements
   function compareSIDContent() {
     if (SIDsB.length === 0) {
       if (SIDsA.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ import {check336, check337, check338} from './field33X';
 import {check773} from './field773';
 import {checkLeader} from './leader';
 import {check005, check008} from './controlFields';
+import {compareRecordsPartSetFeatures} from './partsAndSets';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:index');
 
@@ -80,7 +81,8 @@ const comparisonTasks = [ // NB! These are/should be in priority order!
   {'description': '040$b (language of cataloging) (preference only)', 'function': check040b},
   {'description': '040$e (description conventions) (preference only)', 'function': check040e},
   {'description': 'SID test (validation and preference)', 'function': checkSID},
-  {'description': '005 timestamp test (validation and preference)', 'function': check005}
+  {'description': '005 timestamp test (validation and preference)', 'function': check005},
+  {'description': 'Parts vs checks test (validation)', 'function': compareRecordsPartSetFeatures}
 ];
 
 // Apply some recursion evilness/madness/badness to perform only the tests we really really really want.
@@ -136,7 +138,7 @@ export default ({record1Object, record2Object, checkPreference = true, record1Ex
   // console.log('ENTER THE PROGRAM');
 
   const result = makeComparisons({record1, record2, checkPreference, record1External, record2External});
-  console.log(`Comparison result: ${result.result}, reason: ${result.reason}`); // eslint-disable-line no-console
+  debug(`Comparison result: ${result.result}, reason: ${result.reason}`);
   if (result.result === false) {
     return {action: false, preference: false, message: result.reason};
   }

--- a/src/partsAndSets.js
+++ b/src/partsAndSets.js
@@ -1,0 +1,69 @@
+/**
+*
+* @licstart  The following is the entire license notice for the JavaScript code in this file.
+*
+* Melinda record match validator modules for Javascript
+*
+* Copyright (C) 2021-2022 University Of Helsinki (The National Library Of Finland)
+*
+* This file is part of melinda-record-match-validator
+*
+* melinda-record-match-validator program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* melinda-record-match-validator is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* @licend  The above is the entire license notice
+* for the JavaScript code in this file.
+*
+*/
+//import createDebugLogger from 'debug';
+
+//const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:partsAndSets:test');
+//const debugData = debug.extend('data');
+
+
+// Extract partSetFeatures from a record
+export function getPartSetFeatures(record) {
+  if (record) {
+    return {type: 'unknown'};
+  }
+  return {type: 'unknown'};
+}
+
+// Compare two records by their partSetFeatures
+export function compareRecordsPartSetFeatures({record1, record2}) {
+
+  const partSetFeatures1 = getPartSetFeatures(record1);
+  const partSetFeatures2 = getPartSetFeatures(record2);
+
+  return checkPartSetFeatures({partSetFeatures1, partSetFeatures2});
+}
+
+// Check two sets of partSetFeatures
+export function checkPartSetFeatures({partSetFeatures1, partSetFeatures2}) {
+
+  if (partSetFeatures1.type === partSetFeatures2.type) {
+    return true;
+  }
+
+  if (partSetFeatures1.type === 'unknown' || partSetFeatures2.type === 'unknown') {
+    return true;
+  }
+
+  if (partSetFeatures1.type !== partSetFeatures2.type) {
+    return false;
+  }
+
+  // Fallback, but we should not end up here
+  return false;
+}
+

--- a/src/partsAndSets.js
+++ b/src/partsAndSets.js
@@ -4,7 +4,7 @@
 *
 * Melinda record match validator modules for Javascript
 *
-* Copyright (C) 2021-2022 University Of Helsinki (The National Library Of Finland)
+* Copyright (C) 2022 University Of Helsinki (The National Library Of Finland)
 *
 * This file is part of melinda-record-match-validator
 *
@@ -24,20 +24,84 @@
 * @licend  The above is the entire license notice
 * for the JavaScript code in this file.
 *
+*
 */
-//import createDebugLogger from 'debug';
 
-//const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:partsAndSets:test');
-//const debugData = debug.extend('data');
+import {get245} from './field245';
+import {getExtentsForPartsAndSets} from './partsAndSetsExtent';
 
+import createDebugLogger from 'debug';
+
+const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:partsAndSets:test');
+const debugData = debug.extend('data');
 
 // Extract partSetFeatures from a record
 export function getPartSetFeatures(record) {
-  if (record) {
-    return {type: 'unknown'};
+
+  // Get parts and sets features from f300 : extent
+  const extentsForPartsAndSets = getExtentsForPartsAndSets(record);
+  debugData(extentsForPartsAndSets);
+  // Get parts and sets feature from f245 subfields for parts
+  const titleForPartsAndSets = getTitleForPartsAndSets(record);
+  debugData(titleForPartsAndSets);
+
+  // We should also get parts and sets features from:
+
+  // * StandardIdentifiers and their qualifiers
+  //    * if record has two ISBNs with qualifiers 'Part 1' and 'Part 2' it's a record for a set
+  //    * if record has only one ISBN with qualifier 'set' it's a record for a set
+  //    * if record has two ISBNs with qualifiers 'Part 2' and 'set' it's a record for a part
+
+  // * Notefields 500/515
+  //    * if record has field 500/515 with note 'ISBN for complete set', it's probably a record for a part - 020 has ISBN for the part
+
+  // Different fields with $3
+  //    * if record has fields that have subfields $3 like 'Part 1', 'Part 2' it's probably a record for a set
+
+  const allTypes = [titleForPartsAndSets.type, ...extentsForPartsAndSets.map(extent => extent.type)];
+  debugData(allTypes);
+
+  function getTypeFromAllTypes(allTypes) {
+
+    // If we have set-type features and no part-type features we can assume the record is of type 'set'
+    if (allTypes.some((type) => type === 'set') && !allTypes.some((type) => type === 'part')) {
+      return 'set';
+    }
+
+    // If we have part-type features and no part-type features we can assume the record is of type 'part'
+    if (allTypes.some((type) => type === 'part') && !allTypes.some((type) => type === 'set')) {
+      return 'part';
+    }
+
+    // If we have both part-type features and set-type features, or no part-set-features assume we don't know the type
+    return 'unknown';
   }
-  return {type: 'unknown'};
+
+  return {
+    type: getTypeFromAllTypes(allTypes),
+    details: {
+      extentsForPartsAndSets,
+      titleForPartsAndSets
+    }
+  };
 }
+
+export function getTitleForPartsAndSets(record) {
+  const title = get245(record);
+  const type = getTitleType(title);
+
+  return {...title, type};
+}
+
+export function getTitleType(title) {
+  // If there is subfield $p or $n in the title field, we can assume that the record describes a part
+  const type = title.nameOfPartInSectionOfAWork !== 'undefined' || title.numberOfPartInSectionOfAWork !== 'undefined' ? 'part' : 'unknown';
+
+  // we could also make guesses about numbers / roman numerals in the actual title subfields $a and $b
+
+  return type;
+}
+
 
 // Compare two records by their partSetFeatures
 export function compareRecordsPartSetFeatures({record1, record2}) {

--- a/src/partsAndSets.spec.js
+++ b/src/partsAndSets.spec.js
@@ -4,7 +4,7 @@
 *
 * Melinda record match validator modules for Javascript
 *
-* Copyright (C) 2022 University Of Helsinki (The National Library Of Finland)
+* Copyright (C) 2020 University Of Helsinki (The National Library Of Finland)
 *
 * This file is part of melinda-record-match-validator
 *
@@ -29,20 +29,20 @@
 import {expect} from 'chai';
 import {READERS} from '@natlibfi/fixura';
 import generateTests from '@natlibfi/fixugen';
+import {getPartSetFeatures, checkPartSetFeatures} from './partsAndSets';
 import createDebugLogger from 'debug';
-import {compareArrayContent, compareValueContent} from './compareUtils';
 
 
-const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:compareRecordValues:compareUtils:test');
+const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:partsAndSets:test');
 const debugData = debug.extend('data');
 
-testValue();
-testArray();
+testGet();
+testCheck();
 
-function testValue() {
+function testGet() {
   generateTests({
     callback,
-    path: [__dirname, '..', '..', 'test-fixtures', 'compareFunctions', 'compareValue'],
+    path: [__dirname, '..', 'test-fixtures', 'partsAndSets', 'getPartSetFeatures'],
     useMetadataFile: true,
     recurse: false,
     fixura: {
@@ -50,32 +50,28 @@ function testValue() {
     }
   });
 
-  function callback({valueA, valueB, prefix = '', expectedResult}) {
-    debugData(`Comparing values A: ${valueA} and B ${valueB} (prefix: ${prefix})`);
-    const resultValue = compareValueContent(valueA, valueB, prefix);
-    debugData(`Result: ${resultValue}`);
-    debugData(`ExpectedResult: ${expectedResult}`);
-
-
-    expect(resultValue).to.eql(expectedResult);
+  function callback({getFixture, expectedResults}) {
+    const record = getFixture('record.json');
+    debugData(record);
+    const partSetFeatures = getPartSetFeatures(record);
+    expect(partSetFeatures).to.eql(expectedResults);
   }
 }
 
-function testArray() {
+function testCheck() {
   generateTests({
     callback,
-    path: [__dirname, '..', '..', 'test-fixtures', 'compareFunctions', 'compareArray'],
+    path: [__dirname, '..', 'test-fixtures', 'partsAndSets', 'checkPartSetFeatures'],
     useMetadataFile: true,
     recurse: false,
     fixura: {
-      reader: READERS.JSON
+      reader: READERS.JSON1
     }
   });
 
-  function callback({arrayA, arrayB, expectedResult}) {
-
-    const result = compareArrayContent(arrayA, arrayB);
-
-    expect(result).to.eql(expectedResult);
+  function callback({recordValuesA, recordValuesB, expectedResults}) {
+    const checkResults = checkPartSetFeatures({partSetFeatures1: recordValuesA, partSetFeatures2: recordValuesB});
+    debug(`Result: ${checkResults}`);
+    expect(checkResults).to.eql(expectedResults);
   }
 }

--- a/src/partsAndSets.spec.js
+++ b/src/partsAndSets.spec.js
@@ -29,7 +29,7 @@
 import {expect} from 'chai';
 import {READERS} from '@natlibfi/fixura';
 import generateTests from '@natlibfi/fixugen';
-import {getPartSetFeatures, checkPartSetFeatures} from './partsAndSets';
+import {getPartSetFeatures, checkPartSetFeatures, getTitleType} from './partsAndSets';
 import {MarcRecord} from '@natlibfi/marc-record';
 import createDebugLogger from 'debug';
 
@@ -39,6 +39,7 @@ const debugData = debug.extend('data');
 
 testGet();
 testCheck();
+testTitle();
 
 function testGet() {
   generateTests({
@@ -75,5 +76,28 @@ function testCheck() {
     const checkResults = checkPartSetFeatures({partSetFeatures1: recordValuesA, partSetFeatures2: recordValuesB});
     debug(`Result: ${checkResults}`);
     expect(checkResults).to.eql(expectedResults);
+  }
+}
+
+function testTitle() {
+  testGetTitleType();
+
+  function testGetTitleType() {
+    generateTests({
+      callback,
+      path: [__dirname, '..', 'test-fixtures', 'partsAndSets', 'partsAndSetsTitle'],
+      useMetadataFile: true,
+      recurse: false,
+      fixura: {
+        reader: READERS.JSON1
+      }
+    });
+
+    function callback({title, expectedResults}) {
+      debug(`Testing: ${JSON.stringify(title)}`);
+      const type = getTitleType(title);
+      debug(`Result: ${type}`);
+      expect(type).to.eql(expectedResults);
+    }
   }
 }

--- a/src/partsAndSetsExtent.js
+++ b/src/partsAndSetsExtent.js
@@ -1,0 +1,113 @@
+/**
+*
+* @licstart  The following is the entire license notice for the JavaScript code in this file.
+*
+* Melinda record match validator modules for Javascript
+*
+* Copyright (C) 2022 University Of Helsinki (The National Library Of Finland)
+*
+* This file is part of melinda-record-match-validator
+*
+* melinda-record-match-validator program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* melinda-record-match-validator is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* @licend  The above is the entire license notice
+* for the JavaScript code in this file.
+*
+*
+*/
+
+import {hasFields, getSubfield, stripPunc} from './collectFunctions/collectUtils';
+
+
+import createDebugLogger from 'debug';
+
+const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:partsAndSets:test');
+const debugData = debug.extend('data');
+
+
+export function getExtentsForPartsAndSets(record) {
+  const f300s = hasFields('300', record, f300ToJSON);
+  debug('Field 300 info: %o', f300s);
+  return f300s;
+
+  function f300ToJSON(field) {
+
+    // Note: $a is repeatable, this should fetch all $a subfields
+    // Repeated $a:s are pretty rare, though
+    const extentString = getSubfield(field, 'a');
+    debugData(`f300 $a: ${extentString}`);
+    const extentArray = parseExtentString(extentString);
+    const type = getExtentType(extentArray);
+
+    const extent = {
+      type,
+      string: extentString,
+      array: extentArray,
+      additionalExtent: undefined
+    };
+
+    // we get the non-repeatable $e for additionla materials
+    const additionalExtentString = getSubfield(field, 'e');
+    debugData(`f300 $e: ${additionalExtentString}`);
+
+    if (additionalExtentString && additionalExtentString !== 'undefined') {
+      const additionalExtentArray = parseExtentString(additionalExtentString);
+      const additionalType = getExtentType(additionalExtentArray);
+
+      return {
+        ...extent,
+        additionalExtent: {
+          string: additionalExtentString,
+          array: additionalExtentArray,
+          type: additionalType
+        }
+      };
+    }
+    return extent;
+  }
+}
+
+export function getExtentType(extentArray) {
+  debug(`Getting extentType from extentArray`);
+  debugData(extentArray);
+  if (extentArray.some(extent => extent.amount > 1 && extent.unit.match(/vol|volumes|nidettä/iu))) {
+    return 'set';
+  }
+  return 'unknown';
+}
+
+
+export function parseExtentString(extentString) {
+  debug(`Handling extentString: |${extentString}|`);
+  const punctlessString = stripPunc(extentString);
+  debug(`Removed punctuation: |${punctlessString}|`);
+  // get all extent-clauses like: "2 vol", "248 pages", "1 verkkoaineisto"
+  // we probably should be able to handle also roman numerals to amount
+
+  // \w does not match äåå?
+  // should we handle X unit (Y unit2 Z unit3) cases somehow?
+  //const regexpExtent = /(?<amount>\d+) (?<unit>[\w]+)/mgu;
+  const regexpExtent = /(?<amount>\p{N}+) (?<unit>[\p{L}\p{N}-]+)/mgu;
+
+  const foundExtents = [];
+  // eslint-disable-next-line functional/no-loop-statement
+  for (const match of punctlessString.matchAll(regexpExtent)) {
+    debug(`amount: ${match.groups.amount} unit: ${match.groups.unit}`);
+    // eslint-disable-next-line functional/immutable-data
+    foundExtents.push({amount: match.groups.amount, unit: match.groups.unit});
+  }
+
+  debugData(JSON.stringify(foundExtents));
+  return foundExtents;
+}

--- a/src/partsAndSetsExtent.js
+++ b/src/partsAndSetsExtent.js
@@ -81,7 +81,8 @@ export function getExtentsForPartsAndSets(record) {
 export function getExtentType(extentArray) {
   debug(`Getting extentType from extentArray`);
   debugData(extentArray);
-  if (extentArray.some(extent => extent.amount > 1 && extent.unit.match(/vol|volumes|nidettä/iu))) {
+  const setTypeUnitsRegex = /vol|volumes|nidettä|osaa|band/iu;
+  if (extentArray.some(extent => extent.amount > 1 && extent.unit.match(setTypeUnitsRegex))) {
     return 'set';
   }
   return 'unknown';

--- a/src/partsAndSetsExtent.spec.js
+++ b/src/partsAndSetsExtent.spec.js
@@ -29,21 +29,20 @@
 import {expect} from 'chai';
 import {READERS} from '@natlibfi/fixura';
 import generateTests from '@natlibfi/fixugen';
-import {getPartSetFeatures, checkPartSetFeatures} from './partsAndSets';
-import {MarcRecord} from '@natlibfi/marc-record';
-import createDebugLogger from 'debug';
+import {parseExtentString, getExtentType} from './partsAndSetsExtent';
+//import createDebugLogger from 'debug';
 
 
-const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:partsAndSets:test');
-const debugData = debug.extend('data');
+//const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:partsAndSets:test');
+//const debugData = debug.extend('data');
 
-testGet();
-testCheck();
+testParseExtentString();
+testGetExtentType();
 
-function testGet() {
+function testParseExtentString() {
   generateTests({
     callback,
-    path: [__dirname, '..', 'test-fixtures', 'partsAndSets', 'getPartSetFeatures'],
+    path: [__dirname, '..', 'test-fixtures', 'partsAndSetsExtent', 'parseExtentString'],
     useMetadataFile: true,
     recurse: false,
     fixura: {
@@ -51,29 +50,30 @@ function testGet() {
     }
   });
 
-  function callback({getFixture, expectedResults}) {
-    const record = new MarcRecord(getFixture('record.json'), {subfieldValues: false});
-    debugData(record);
-    const partSetFeatures = getPartSetFeatures(record);
-    debugData(partSetFeatures);
-    expect(partSetFeatures.type).to.eql(expectedResults.type);
+  function callback({string, expectedResults}) {
+
+    const result = parseExtentString(string);
+    expect(result).to.eql(expectedResults);
   }
 }
 
-function testCheck() {
+
+function testGetExtentType() {
   generateTests({
     callback,
-    path: [__dirname, '..', 'test-fixtures', 'partsAndSets', 'checkPartSetFeatures'],
+    path: [__dirname, '..', 'test-fixtures', 'partsAndSetsExtent', 'getExtentType'],
     useMetadataFile: true,
     recurse: false,
     fixura: {
-      reader: READERS.JSON1
+      reader: READERS.JSON
     }
   });
 
-  function callback({recordValuesA, recordValuesB, expectedResults}) {
-    const checkResults = checkPartSetFeatures({partSetFeatures1: recordValuesA, partSetFeatures2: recordValuesB});
-    debug(`Result: ${checkResults}`);
-    expect(checkResults).to.eql(expectedResults);
+  function callback({array, expectedResults}) {
+
+    const result = getExtentType(array);
+    expect(result).to.eql(expectedResults);
   }
 }
+
+

--- a/test-fixtures/index/partsAndSetsFailure/expectedResults.json
+++ b/test-fixtures/index/partsAndSetsFailure/expectedResults.json
@@ -1,0 +1,5 @@
+{
+    "action": false,
+    "message": "Parts vs checks test (validation) failed",
+    "preference": false
+}

--- a/test-fixtures/index/partsAndSetsFailure/inputRecordA.json
+++ b/test-fixtures/index/partsAndSetsFailure/inputRecordA.json
@@ -1,0 +1,420 @@
+{
+  "leader": "02684cam a22006977i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001034875"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20220425113408.0"
+    },
+    {
+      "tag": "008",
+      "value": "871026s1984    fi |||||||||||||||||fin||"
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "951-95145-6-2"
+        },
+        {
+          "code": "q",
+          "value": "osa 1"
+        }
+      ]
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "951-9026-00-2"
+        },
+        {
+          "code": "q",
+          "value": "osa 2"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001034875"
+        }
+      ]
+    },
+    {
+      "tag": "041",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "fin"
+        }
+      ]
+    },
+    {
+      "tag": "100",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Aaltonen, Esko."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Entisajan Forssaa ja sen väkeä /"
+        },
+        {
+          "code": "c",
+          "value": "Esko Aaltonen."
+        }
+      ]
+    },
+    {
+      "tag": "250",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "3. p."
+        }
+      ]
+    },
+    {
+      "tag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa :"
+        },
+        {
+          "code": "b",
+          "value": "Forssan kustannus,"
+        },
+        {
+          "code": "c",
+          "value": "1984-86."
+        }
+      ]
+    },
+    {
+      "tag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "2 vol."
+        }
+      ]
+    },
+    {
+      "tag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "teksti"
+        },
+        {
+          "code": "b",
+          "value": "txt"
+        },
+        {
+          "code": "2",
+          "value": "rdacontent"
+        }
+      ]
+    },
+    {
+      "tag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "käytettävissä ilman laitetta"
+        },
+        {
+          "code": "b",
+          "value": "n"
+        },
+        {
+          "code": "2",
+          "value": "rdamedia"
+        }
+      ]
+    },
+    {
+      "tag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "nide"
+        },
+        {
+          "code": "b",
+          "value": "nc"
+        },
+        {
+          "code": "2",
+          "value": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "1. p:n nimi: Vanhan Forssan elämää."
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "2. laaj. laitos 1947-51."
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "1. p. nimellä Vanhan Forssan elämää, 1932-33."
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "paikallishistoriat (historiikit)"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1779"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "kaupungit"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1688"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historiikit"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1778"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "lokalhistoriker"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1779"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "städer"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1688"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historiker (verk)"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1778"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/index/partsAndSetsFailure/inputRecordB.json
+++ b/test-fixtures/index/partsAndSetsFailure/inputRecordB.json
@@ -1,0 +1,402 @@
+{
+  "leader": "03635cam a2200997 i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001295514"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20220928150456.0"
+    },
+    {
+      "tag": "008",
+      "value": "841012s1984    fi |||||||||||||||||fin| "
+    },
+    {
+      "tag": "015",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "fx128723"
+        },
+        {
+          "code": "2",
+          "value": "skl"
+        }
+      ]
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "951-95145-6-2"
+        },
+        {
+          "code": "q",
+          "value": "nidottu"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001295514"
+        }
+      ]
+    },
+    {
+      "tag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "FI-NL"
+        },
+        {
+          "code": "b",
+          "value": "fin"
+        }
+      ]
+    },
+    {
+      "tag": "041",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "fin"
+        }
+      ]
+    },
+    {
+      "tag": "042",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "finb"
+        }
+      ]
+    },
+    {
+      "tag": "100",
+      "ind1": "1",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Aaltonen, Esko,"
+        },
+        {
+          "code": "d",
+          "value": "1893-1966."
+        },
+        {
+          "code": "0",
+          "value": "(FI-ASTERI-N)000039756"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Entisajan Forssaa ja sen väkeä."
+        },
+        {
+          "code": "n",
+          "value": "1 /"
+        },
+        {
+          "code": "c",
+          "value": "Esko Aaltonen."
+        }
+      ]
+    },
+    {
+      "tag": "250",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "3. p."
+        }
+      ]
+    },
+    {
+      "tag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa :"
+        },
+        {
+          "code": "b",
+          "value": "Forssan kustannus,"
+        },
+        {
+          "code": "c",
+          "value": "1984"
+        },
+        {
+          "code": "f",
+          "value": "(Forssan kirjap.)"
+        }
+      ]
+    },
+    {
+      "tag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "248 sivua :"
+        },
+        {
+          "code": "b",
+          "value": "kuvitettu, karttoja ;"
+        },
+        {
+          "code": "c",
+          "value": "24 cm"
+        }
+      ]
+    },
+    {
+      "tag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "teksti"
+        },
+        {
+          "code": "b",
+          "value": "txt"
+        },
+        {
+          "code": "2",
+          "value": "rdacontent"
+        }
+      ]
+    },
+    {
+      "tag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "käytettävissä ilman laitetta"
+        },
+        {
+          "code": "b",
+          "value": "n"
+        },
+        {
+          "code": "2",
+          "value": "rdamedia"
+        }
+      ]
+    },
+    {
+      "tag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "nide"
+        },
+        {
+          "code": "b",
+          "value": "nc"
+        },
+        {
+          "code": "2",
+          "value": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "1. p. nimellä Vanhan Forssan elämää, 1932-33."
+        },
+        {
+          "code": "9",
+          "value": "FENNI<KEEP>"
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "2. laaj. laitos 1947-51"
+        },
+        {
+          "code": "9",
+          "value": "FENNI<KEEP>"
+        }
+      ]
+    },
+    {
+      "tag": "610",
+      "ind1": "1",
+      "ind2": "4",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssan kaupunki."
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "paikallishistoria (historia)"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p9783"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "lokalhistoria"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p9783"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    }
+   ]
+}

--- a/test-fixtures/index/partsAndSetsFailure/metadata.json
+++ b/test-fixtures/index/partsAndSetsFailure/metadata.json
@@ -1,0 +1,6 @@
+{
+    "description": "Fail validation when partAndSets validation fails",
+    "enabled": true,
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSets/checkPartSetFeatures/01/metadata.json
+++ b/test-fixtures/partsAndSets/checkPartSetFeatures/01/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Return true if both records have partSetFeature.type: unknown",
+    "recordValuesA": {"type": "unknown"},
+    "recordValuesB": {"type": "unknown"},
+    "expectedResults": true,
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/checkPartSetFeatures/02/metadata.json
+++ b/test-fixtures/partsAndSets/checkPartSetFeatures/02/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Return false if both records have opposing (part/set) partSetFeature.type",
+    "recordValuesA": {"type": "part"},
+    "recordValuesB": {"type": "set"},
+    "expectedResults": false,
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/checkPartSetFeatures/03/metadata.json
+++ b/test-fixtures/partsAndSets/checkPartSetFeatures/03/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Return true if one record B has partSetFeature.type: unknown and record A has a defined partSetFeature.type",
+    "recordValuesA": {"type": "part"},
+    "recordValuesB": {"type": "unknown"},
+    "expectedResults": true,
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/checkPartSetFeatures/04/metadata.json
+++ b/test-fixtures/partsAndSets/checkPartSetFeatures/04/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Return true if one record A has partSetFeature.type: unknown and record B has a defined partSetFeature.type",
+    "recordValuesA": {"type": "unknown"},
+    "recordValuesB": {"type": "set"},
+    "expectedResults": true,
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/checkPartSetFeatures/05/metadata.json
+++ b/test-fixtures/partsAndSets/checkPartSetFeatures/05/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Return true if both records have same partSetFeature.type",
+    "recordValuesA": {"type": "part"},
+    "recordValuesB": {"type": "part"},
+    "expectedResults": true,
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/getPartSetFeatures/01/metadata.json
+++ b/test-fixtures/partsAndSets/getPartSetFeatures/01/metadata.json
@@ -1,0 +1,5 @@
+{
+    "description": "Return type:unknown if record has no partSetFeatures",
+    "expectedResults": {"type": "unknown"},
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/getPartSetFeatures/01/record.json
+++ b/test-fixtures/partsAndSets/getPartSetFeatures/01/record.json
@@ -1,0 +1,405 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "SID",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "b",
+          "value": "organisaatio"
+        },
+        {
+          "code": "c",
+          "value": "000666000"
+        }
+      ]
+    },
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20101104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "022",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0794-7348"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001275159"
+        }
+      ]
+    },
+    {
+      "tag": "041",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "eng"
+        }
+      ]
+    },
+    {
+      "tag": "080",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "616.314"
+        }
+      ]
+    },
+    {
+      "tag": "210",
+      "ind1": "1",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Afr Dent J."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    {
+      "tag": "246",
+      "ind1": "1",
+      "ind2": "1",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Journal dentaire Africain."
+        }
+      ]
+    },
+    {
+      "tag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "teksti"
+        },
+        {
+          "code": "b",
+          "value": "txt"
+        },
+        {
+          "code": "2",
+          "value": "rdacontent"
+        }
+      ]
+    },
+    {
+      "tag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "käytettävissä ilman laitetta"
+        },
+        {
+          "code": "b",
+          "value": "n"
+        },
+        {
+          "code": "2",
+          "value": "rdamedia"
+        }
+      ]
+    },
+    {
+      "tag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "nide"
+        },
+        {
+          "code": "b",
+          "value": "nc"
+        },
+        {
+          "code": "2",
+          "value": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "2",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Dentistry"
+        },
+        {
+          "code": "x",
+          "value": "periodicals"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "2",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Dentistry"
+        }
+      ]
+    },
+    {
+      "tag": "653",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "kausijulkaisut"
+        },
+        {
+          "code": "a",
+          "value": "hammaslääketiede"
+        }
+      ]
+    },
+    {
+      "tag": "655",
+      "ind1": " ",
+      "ind2": "2",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Periodicals"
+        }
+      ]
+    },
+    {
+      "tag": "740",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Afr Dent J."
+        }
+      ]
+    },
+    {
+      "tag": "960",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "ARTO"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "CONV-ISBD"
+        },
+        {
+          "code": "b"
+        },
+        {
+          "code": "c",
+          "value": "20120402"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0819"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-HELKA"
+        },
+        {
+          "code": "b"
+        },
+        {
+          "code": "c",
+          "value": "20140520"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0018"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-HELKA"
+        },
+        {
+          "code": "b"
+        },
+        {
+          "code": "c",
+          "value": "20140609"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "2320"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "REM-HELKA"
+        },
+        {
+          "code": "b"
+        },
+        {
+          "code": "c",
+          "value": "20150702"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "2234"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "CONV-RDA"
+        },
+        {
+          "code": "b"
+        },
+        {
+          "code": "c",
+          "value": "20160319"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0822"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-FIX"
+        },
+        {
+          "code": "b",
+          "value": "30"
+        },
+        {
+          "code": "c",
+          "value": "20201104"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0046"
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/partsAndSets/getPartSetFeatures/02/metadata.json
+++ b/test-fixtures/partsAndSets/getPartSetFeatures/02/metadata.json
@@ -1,0 +1,5 @@
+{
+    "description": "Return type:part if record has partSetFeatures of part",
+    "expectedResults": {"type": "part"},
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/getPartSetFeatures/02/record.json
+++ b/test-fixtures/partsAndSets/getPartSetFeatures/02/record.json
@@ -1,0 +1,402 @@
+{
+  "leader": "03635cam a2200997 i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001295514"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20220928150456.0"
+    },
+    {
+      "tag": "008",
+      "value": "841012s1984    fi |||||||||||||||||fin| "
+    },
+    {
+      "tag": "015",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "fx128723"
+        },
+        {
+          "code": "2",
+          "value": "skl"
+        }
+      ]
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "951-95145-6-2"
+        },
+        {
+          "code": "q",
+          "value": "nidottu"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001295514"
+        }
+      ]
+    },
+    {
+      "tag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "FI-NL"
+        },
+        {
+          "code": "b",
+          "value": "fin"
+        }
+      ]
+    },
+    {
+      "tag": "041",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "fin"
+        }
+      ]
+    },
+    {
+      "tag": "042",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "finb"
+        }
+      ]
+    },
+    {
+      "tag": "100",
+      "ind1": "1",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Aaltonen, Esko,"
+        },
+        {
+          "code": "d",
+          "value": "1893-1966."
+        },
+        {
+          "code": "0",
+          "value": "(FI-ASTERI-N)000039756"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Entisajan Forssaa ja sen väkeä."
+        },
+        {
+          "code": "n",
+          "value": "1 /"
+        },
+        {
+          "code": "c",
+          "value": "Esko Aaltonen."
+        }
+      ]
+    },
+    {
+      "tag": "250",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "3. p."
+        }
+      ]
+    },
+    {
+      "tag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa :"
+        },
+        {
+          "code": "b",
+          "value": "Forssan kustannus,"
+        },
+        {
+          "code": "c",
+          "value": "1984"
+        },
+        {
+          "code": "f",
+          "value": "(Forssan kirjap.)"
+        }
+      ]
+    },
+    {
+      "tag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "248 sivua :"
+        },
+        {
+          "code": "b",
+          "value": "kuvitettu, karttoja ;"
+        },
+        {
+          "code": "c",
+          "value": "24 cm"
+        }
+      ]
+    },
+    {
+      "tag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "teksti"
+        },
+        {
+          "code": "b",
+          "value": "txt"
+        },
+        {
+          "code": "2",
+          "value": "rdacontent"
+        }
+      ]
+    },
+    {
+      "tag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "käytettävissä ilman laitetta"
+        },
+        {
+          "code": "b",
+          "value": "n"
+        },
+        {
+          "code": "2",
+          "value": "rdamedia"
+        }
+      ]
+    },
+    {
+      "tag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "nide"
+        },
+        {
+          "code": "b",
+          "value": "nc"
+        },
+        {
+          "code": "2",
+          "value": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "1. p. nimellä Vanhan Forssan elämää, 1932-33."
+        },
+        {
+          "code": "9",
+          "value": "FENNI<KEEP>"
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "2. laaj. laitos 1947-51"
+        },
+        {
+          "code": "9",
+          "value": "FENNI<KEEP>"
+        }
+      ]
+    },
+    {
+      "tag": "610",
+      "ind1": "1",
+      "ind2": "4",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssan kaupunki."
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "paikallishistoria (historia)"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p9783"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "lokalhistoria"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p9783"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    }
+   ]
+}

--- a/test-fixtures/partsAndSets/getPartSetFeatures/03/metadata.json
+++ b/test-fixtures/partsAndSets/getPartSetFeatures/03/metadata.json
@@ -1,0 +1,5 @@
+{
+    "description": "Return type:set if record has partSetFeatures of type set",
+    "expectedResults": {"type": "set"},
+    "skip": false
+}

--- a/test-fixtures/partsAndSets/getPartSetFeatures/03/record.json
+++ b/test-fixtures/partsAndSets/getPartSetFeatures/03/record.json
@@ -1,0 +1,420 @@
+{
+  "leader": "02684cam a22006977i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001034875"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20220425113408.0"
+    },
+    {
+      "tag": "008",
+      "value": "871026s1984    fi |||||||||||||||||fin||"
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "951-95145-6-2"
+        },
+        {
+          "code": "q",
+          "value": "osa 1"
+        }
+      ]
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "951-9026-00-2"
+        },
+        {
+          "code": "q",
+          "value": "osa 2"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001034875"
+        }
+      ]
+    },
+    {
+      "tag": "041",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "fin"
+        }
+      ]
+    },
+    {
+      "tag": "100",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Aaltonen, Esko."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Entisajan Forssaa ja sen väkeä /"
+        },
+        {
+          "code": "c",
+          "value": "Esko Aaltonen."
+        }
+      ]
+    },
+    {
+      "tag": "250",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "3. p."
+        }
+      ]
+    },
+    {
+      "tag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa :"
+        },
+        {
+          "code": "b",
+          "value": "Forssan kustannus,"
+        },
+        {
+          "code": "c",
+          "value": "1984-86."
+        }
+      ]
+    },
+    {
+      "tag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "2 vol."
+        }
+      ]
+    },
+    {
+      "tag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "teksti"
+        },
+        {
+          "code": "b",
+          "value": "txt"
+        },
+        {
+          "code": "2",
+          "value": "rdacontent"
+        }
+      ]
+    },
+    {
+      "tag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "käytettävissä ilman laitetta"
+        },
+        {
+          "code": "b",
+          "value": "n"
+        },
+        {
+          "code": "2",
+          "value": "rdamedia"
+        }
+      ]
+    },
+    {
+      "tag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "nide"
+        },
+        {
+          "code": "b",
+          "value": "nc"
+        },
+        {
+          "code": "2",
+          "value": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "1. p:n nimi: Vanhan Forssan elämää."
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "2. laaj. laitos 1947-51."
+        }
+      ]
+    },
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "1. p. nimellä Vanhan Forssan elämää, 1932-33."
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "paikallishistoriat (historiikit)"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1779"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "kaupungit"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1688"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historiikit"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1778"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "lokalhistoriker"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1779"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historia"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1780"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "städer"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1688"
+        }
+      ]
+    },
+    {
+      "tag": "650",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "historiker (verk)"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p1778"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/fin"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    },
+    {
+      "tag": "651",
+      "ind1": " ",
+      "ind2": "7",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Forssa"
+        },
+        {
+          "code": "2",
+          "value": "yso/swe"
+        },
+        {
+          "code": "0",
+          "value": "http://www.yso.fi/onto/yso/p94114"
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/partsAndSets/partsAndSetsTitle/01/metadata.json
+++ b/test-fixtures/partsAndSets/partsAndSetsTitle/01/metadata.json
@@ -1,0 +1,12 @@
+{
+    "description": "Get type 'unknown' if there are no names or numbers of parts in title",
+    "title": {
+        "title": "Entisajan Forssaa ja sen väkeä",
+        "remainderOfTitle": "undefined",
+        "numberOfPartInSectionOfAWork": "undefined",
+        "nameOfPartInSectionOfAWork": "undefined"
+    },
+    "expectedResults": "unknown",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSets/partsAndSetsTitle/02/metadata.json
+++ b/test-fixtures/partsAndSets/partsAndSetsTitle/02/metadata.json
@@ -1,0 +1,12 @@
+{
+    "description": "Get type 'unknown' if number of part includes several numbers connected with a hyphen",
+    "title": {
+        "title": "Le Georgiche",
+        "remainderOfTitle": "undefined",
+        "numberOfPartInSectionOfAWork": "Libri 1-2",
+        "nameOfPartInSectionOfAWork": "Foobar"
+    },
+    "expectedResults": "unknown",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSets/partsAndSetsTitle/03/metadata.json
+++ b/test-fixtures/partsAndSets/partsAndSetsTitle/03/metadata.json
@@ -1,0 +1,12 @@
+{
+    "description": "Get type 'part' if there is a name of a part",
+    "title": {
+        "title": "Entisajan Forssaa ja sen väkeä",
+        "remainderOfTitle": "undefined",
+        "numberOfPartInSectionOfAWork": "undefined",
+        "nameOfPartInSectionOfAWork": "Alkutarina"
+    },
+    "expectedResults": "part",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSets/partsAndSetsTitle/04/metadata.json
+++ b/test-fixtures/partsAndSets/partsAndSetsTitle/04/metadata.json
@@ -1,0 +1,12 @@
+{
+    "description": "Get type 'part' if there is a number of a par",
+    "title": {
+        "title": "Entisajan Forssaa ja sen väkeä",
+        "remainderOfTitle": "undefined",
+        "numberOfPartInSectionOfAWork": "Osa 1",
+        "nameOfPartInSectionOfAWork": "Osan nimi"
+    },
+    "expectedResults": "part",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/getExtentType/01/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/01/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Get type set from several extents",
+    "description": "Get type 'set' from several extents",
     "array": [
         {"amount": "36", "unit": "sivua"},
         {"amount": "3", "unit": "nidettä"},

--- a/test-fixtures/partsAndSetsExtent/getExtentType/01/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/01/metadata.json
@@ -1,0 +1,12 @@
+{
+    "description": "Get type set from several extents",
+    "array": [
+        {"amount": "36", "unit": "sivua"},
+        {"amount": "3", "unit": "nidettä"},
+        {"amount": "13", "unit": "numeroimatonta"},
+        {"amount": "29", "unit": "lehteä"}
+    ],
+    "expectedResults": "set",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/getExtentType/02/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/02/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Get type set from single extent",
+    "description": "Get type 'set' from single extent",
     "array": [{"amount": "2", "unit": "vol"}],
     "expectedResults": "set",
     "skip": false,

--- a/test-fixtures/partsAndSetsExtent/getExtentType/02/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/02/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Get type set from single extent",
+    "array": [{"amount": "2", "unit": "vol"}],
+    "expectedResults": "set",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/getExtentType/03/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/03/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Get type 'part'' if amount is 1 even for a set-type unit",
+    "description": "Get type 'unknown' if amount is 1 even for a set-type unit",
     "array": [{"amount": "1", "unit": "vol"}],
     "expectedResults": "unknown",
     "skip": false,

--- a/test-fixtures/partsAndSetsExtent/getExtentType/03/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/03/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Get type unknown if amount is 1 even for a set-type unit",
+    "description": "Get type 'part'' if amount is 1 even for a set-type unit",
     "array": [{"amount": "1", "unit": "vol"}],
     "expectedResults": "unknown",
     "skip": false,

--- a/test-fixtures/partsAndSetsExtent/getExtentType/03/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/03/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Get type unknown if amount is 1 even for a set-type unit",
+    "array": [{"amount": "1", "unit": "vol"}],
+    "expectedResults": "unknown",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/getExtentType/04/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/04/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Get type unknown for empty array",
+    "array": [],
+    "expectedResults": "unknown",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/getExtentType/04/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/04/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Get type unknown for empty array",
+    "description": "Get type 'unknown' for empty array",
     "array": [],
     "expectedResults": "unknown",
     "skip": false,

--- a/test-fixtures/partsAndSetsExtent/getExtentType/05/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/getExtentType/05/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Get type 'unknown' if there's no set-type unit",
+    "array": [{"amount": "9", "unit": "pages"}],
+    "expectedResults": "unknown",
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/01/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/01/metadata.json
@@ -1,0 +1,6 @@
+{
+    "description": "Split single extent clase to amount and unit",
+    "string": "2 vol. ",
+    "expectedResults": [{"amount": "2", "unit": "vol"}],
+    "skip": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/01/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/01/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Split single extent clase to amount and unit",
+    "description": "Split single extent clause to amount and unit",
     "string": "2 vol. ",
     "expectedResults": [{"amount": "2", "unit": "vol"}],
     "skip": false

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/02/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/02/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "FIX: Split clause correctly - match unit-string correctly",
+    "description": "Split extent clause correctly when unit-string contains diacritics and/or hyphens correctly",
     "string": "1 CD-äänilevy (9 min 9 s)",
     "expectedResults": [
         {"amount": "1", "unit": "CD-äänilevy"},

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/02/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/02/metadata.json
@@ -1,0 +1,11 @@
+{
+    "description": "FIX: Split clause correctly - match unit-string correctly",
+    "string": "1 CD-äänilevy (9 min 9 s)",
+    "expectedResults": [
+        {"amount": "1", "unit": "CD-äänilevy"},
+        {"amount": "9", "unit": "min"},
+        {"amount": "9", "unit": "s"}
+    ],
+    "skip": true,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/03/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/03/metadata.json
@@ -1,0 +1,9 @@
+    {
+        "description": "IMPLEMENT LATER: Split extent clause correctly - handle []-brackets",
+        "string": "[9] s. :",
+        "expectedResults": [
+            {"amount": "9", "unit": "s"}
+        ],
+        "skip": true,
+        "only": false
+    }

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/04/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/04/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Split two-level clause - currently split to two parallel clauses",
+    "description": "FIX: Split two-level clause - currently split to two parallel clauses",
     "string": "1 verkkoaineisto (9 sivua) ",
     "expectedResults": [
         {"amount": "1", "unit": "verkkoaineisto"},

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/04/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/04/metadata.json
@@ -1,0 +1,10 @@
+{
+    "description": "Split two-level clause - currently split to two parallel clauses",
+    "string": "1 verkkoaineisto (9 sivua) ",
+    "expectedResults": [
+        {"amount": "1", "unit": "verkkoaineisto"},
+        {"amount": "9", "unit": "sivua"}
+    ],
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/05/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/05/metadata.json
@@ -1,0 +1,9 @@
+{
+    "description": "Handle + as ending punctuation",
+    "string": "1 CD + ",
+    "expectedResults": [
+        {"amount": "1", "unit": "CD"}
+    ],
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/06/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/06/metadata.json
@@ -1,0 +1,9 @@
+{
+    "description": "IMPLEMENT LATER: Handle Vol. 2-6 type extent (unit before amount, range as amount)",
+    "string": "Vol. 2-6 ; ",
+    "expectedResults": [
+        {"amount": "5", "unit": "Vol"}
+    ],
+    "skip": true,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/07/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/07/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "IMPLEMENT LATER: Handle comma-separated extents with same unit: amount is sum of amounts",
+    "string": "9, 12 s",
+    "expectedResults": [{"amount": "21", "unit": "s"}],
+    "skip": true,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/08/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/08/metadata.json
@@ -3,5 +3,5 @@
     "string": "xv s",
     "expectedResults": [{"amount": "15", "unit": "s"}],
     "skip": true,
-    "only": true
+    "only": false
 }

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/08/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/08/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "IMPLEMENT LATER: Handle amount in roman numerals",
+    "string": "xv s",
+    "expectedResults": [{"amount": "15", "unit": "s"}],
+    "skip": true,
+    "only": true
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/09/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/09/metadata.json
@@ -1,0 +1,12 @@
+{
+    "description": "FIX: Handle three level extent - currently creates parallel extents",
+    "string": "1 verkkoaineisto (1 tiedosto (3 h 2 min))",
+    "expectedResults": [
+        {"amount": "1", "unit": "verkkoaineisto"},
+        {"amount": "1", "unit": "tiedosto"},
+        {"amount": "3", "unit": "h"},
+        {"amount": "2", "unit": "min"}
+    ],
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/10/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/10/metadata.json
@@ -1,0 +1,12 @@
+{
+    "description": "FIX: Handle two level extent with several first level units (currently creates parallel extents)",
+    "string": "3 verkkoaineistoa (9 s, 3 s, 9 s) + ",
+    "expectedResults": [
+        {"amount": "3", "unit": "verkkoaineistoa"},
+        {"amount": "9", "unit": "s"},
+        {"amount": "3", "unit": "s"},
+        {"amount": "9", "unit": "s"}
+    ],
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/10/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/10/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "FIX: Handle two level extent with several first level units (currently creates parallel extents)",
+    "description": "FIX: Handle two level extent with several first level units - currently creates parallel extents",
     "string": "3 verkkoaineistoa (9 s, 3 s, 9 s) + ",
     "expectedResults": [
         {"amount": "3", "unit": "verkkoaineistoa"},

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/11/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/11/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "FIX: Handle hyphen as part of the unit",
+    "string": "2 C-kasettia. ",
+    "expectedResults": [{"amount": "2", "unit": "C-kasettia"}],
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/11/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/11/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "FIX: Handle hyphen as part of the unit",
+    "description": "Handle hyphen as part of the unit",
     "string": "2 C-kasettia. ",
     "expectedResults": [{"amount": "2", "unit": "C-kasettia"}],
     "skip": false,

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/12/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/12/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "FIX: Handle diacritics as part of the unit",
+    "string": "2 nidettä. ",
+    "expectedResults": [{"amount": "2", "unit": "nidettä"}],
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/12/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/12/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "FIX: Handle diacritics as part of the unit",
+    "description": "Handle diacritics as part of the unit",
     "string": "2 nidettä. ",
     "expectedResults": [{"amount": "2", "unit": "nidettä"}],
     "skip": false,

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/13/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/13/metadata.json
@@ -1,0 +1,11 @@
+{
+    "description": "IMPLEMENT LATER: Handle the same extent in two units - currently creates parallel extents",
+    "string": "1 verkkoaineisto (9 KB, 9 sivua)",
+    "expectedResults": [
+        {"amount": "1", "unit": "verkkoaineisto"},
+        {"amount": "9", "unit": "KB"},
+        {"amount": "9", "unit": "sivua"}
+    ],
+    "skip": false,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/13/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/13/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "IMPLEMENT LATER: Handle the same extent in two units - currently creates parallel extents",
+    "description": "FIX: Handle the same extent in two units - currently creates parallel extents",
     "string": "1 verkkoaineisto (9 KB, 9 sivua)",
     "expectedResults": [
         {"amount": "1", "unit": "verkkoaineisto"},

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/14/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/14/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "IMPLEMENT LATER: Normalize duration to one extent",
+    "description": "IMPLEMENT LATER: Normalize duration to a single unit",
     "string": "(2 h 16 min)",
     "expectedResults": [{"amount": "136", "unit": "min"}],
     "skip": true,

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/14/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/14/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "IMPLEMENT LATER: Normalize duration to one extent",
+    "string": "(2 h 16 min)",
+    "expectedResults": [{"amount": "136", "unit": "min"}],
+    "skip": true,
+    "only": false
+}

--- a/test-fixtures/partsAndSetsExtent/parseExtentString/15/metadata.json
+++ b/test-fixtures/partsAndSetsExtent/parseExtentString/15/metadata.json
@@ -1,0 +1,7 @@
+{
+    "description": "Handle number as part of the unit-string",
+    "string": "2 MP3",
+    "expectedResults": [{"amount": "2", "unit": "MP3"}],
+    "skip": false,
+    "only": false
+}


### PR DESCRIPTION
* Add validator to compare records and determine whether the record describes a part or a set 
 - for example a single part of a multi-part monograph (Life in Finland, part 1) or the set of all parts of a multi-part monograph (Life in Finland [parts 1 and 2])