### PR TITLE
MRA-179: LP vs CD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/melinda-record-match-validator",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "LGPL-3.0+",
       "dependencies": {
         "@natlibfi/marc-record": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Validates if two records matched by melinda-record-matching can be merged and sets merge priority",
   "main": "dist/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ import {check773} from './field773';
 import {checkLeader} from './leader';
 import {check005, check008} from './controlFields';
 import {compareRecordsPartSetFeatures} from './partsAndSets';
+import {performAudioSanityCheck} from './sanityCheckAudio';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:index');
 
@@ -68,7 +69,7 @@ const comparisonTasks = [ // NB! These are/should be in priority order!
   {'description': 'existence (validation only)', 'function': checkExistence},
   {'description': 'leader (validation and preference)', 'function': checkLeader}, // Prioritize LDR/17 (encoding level)
   {'description': '008 test (validation and preference)', 'function': check008},
-  {'description': 'publisher (264>260) (preference only)', 'function': checkPublisher},
+  {'description': 'publisher (264>260) (preference only)', 'function': checkPublisher}, // Bit high on the preference list, isn't it?
   {'description': 'LOW test (validation and preference)', 'function': checkLOW}, // Priority order: FIKKA > ANY > NONE
   {'description': 'field 042: authentication code (preference only)', 'function': check042},
   {'description': 'CAT test (preference only)', 'function': checkCAT},
@@ -82,6 +83,7 @@ const comparisonTasks = [ // NB! These are/should be in priority order!
   {'description': '040$e (description conventions) (preference only)', 'function': check040e},
   {'description': 'SID test (validation and preference)', 'function': checkSID},
   {'description': '005 timestamp test (validation and preference)', 'function': check005},
+  {'description': 'audio sanity check (validation only)', 'function': performAudioSanityCheck},
   {'description': 'Parts vs checks test (validation)', 'function': compareRecordsPartSetFeatures}
 ];
 

--- a/src/sanityCheckAudio.js
+++ b/src/sanityCheckAudio.js
@@ -1,0 +1,92 @@
+/**
+*
+* @licstart  The following is the entire license notice for the JavaScript code in this file.
+*
+* Melinda record match validator modules for Javascript
+*
+* Copyright (C) 2021-2022 University Of Helsinki (The National Library Of Finland)
+*
+* This file is part of melinda-record-match-validator
+*
+* melinda-record-match-validator program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* melinda-record-match-validator is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* @licend  The above is the entire license notice
+* for the JavaScript code in this file.
+*
+*/
+
+//import createDebugLogger from 'debug';
+//import {nvdebug} from './utils';
+
+//const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:physicalDescription');
+
+function physicalDescriptionContainsCdAanilevy(fields300) {
+  return fields300.some(field => field.subfields.some(subfield => containsCdAanilevy(subfield)));
+
+  function containsCdAanilevy(subfield) {
+    if (subfield.code !== 'a') {
+      return false;
+    }
+    if (subfield.value.match(/CD-(?:äänilevy|ljudskiv)/ui)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function physicalDescriptionContainsLpAanilevy(fields300) {
+  return fields300.some(field => field.subfields.some(subfield => containsLpAanilevy(subfield)));
+
+  function containsLpAanilevy(subfield) {
+    if (subfield.code !== 'a') {
+      return false;
+    }
+    if (subfield.value.match(/LP-(?:äänilevy|ljudskiv)/ui)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function getPhysicalDescription(record) {
+  const fields = record.get(/^300$/u);
+
+  const result = {
+    containsCdAanilevy: physicalDescriptionContainsCdAanilevy(fields),
+    containsLpAanilevy: physicalDescriptionContainsLpAanilevy(fields)
+  };
+
+  return result;
+}
+
+export function performAudioSanityCheck({record1, record2}) {
+  const results1 = getPhysicalDescription(record1);
+  const results2 = getPhysicalDescription(record2);
+
+  // NB! This won't fail if one 300$a has CD-äänilevy and the other one does not.
+  // This only fails if one is CD and the other is LP.
+  // $a 1 LP-ä
+  const checkLp = results1.containsCdAanilevy || results2.containsCdAanilevy;
+  const checkCd = results1.containsLpAanilevy || results2.containsLpAanilevy;
+
+  if (checkCd && results1.containsCdAanilevy !== results2.containsCdAanilevy) {
+    return false;
+  }
+
+  if (checkLp && results1.containsLpAanilevy !== results2.containsLpAanilevy) {
+    return false;
+  }
+
+  return true;
+}

--- a/test-fixtures/index/300_CD_vs_CD/expectedResults.json
+++ b/test-fixtures/index/300_CD_vs_CD/expectedResults.json
@@ -1,0 +1,7 @@
+{
+    "action": "merge",
+    "preference": {
+        "name": "both records passed all tests, but no winner was found",
+        "value": true
+    }
+}

--- a/test-fixtures/index/300_CD_vs_CD/inputRecordA.json
+++ b/test-fixtures/index/300_CD_vs_CD/inputRecordA.json
@@ -1,0 +1,65 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "022",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0794-7348"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001275159"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+    "subfields": [
+      { "code": "a", "value": "2 CD-äänilevyä (määrä ei merkkaa mitään) +"},
+      { "code": "e", "value": "1 LP-äänilevy ei meinaa tässä mitään"}
+
+    ]
+  }
+  ]
+}

--- a/test-fixtures/index/300_CD_vs_CD/inputRecordB.json
+++ b/test-fixtures/index/300_CD_vs_CD/inputRecordB.json
@@ -1,0 +1,41 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+      "subfields": [
+        { "code": "a", "value": "1 CD-ljudskiva"}
+      ]
+    }
+  ]
+}

--- a/test-fixtures/index/300_CD_vs_CD/metadata.json
+++ b/test-fixtures/index/300_CD_vs_CD/metadata.json
@@ -1,0 +1,4 @@
+{
+    "description": "300$a CD vs CD",
+    "enabled": true
+}

--- a/test-fixtures/index/300_CD_vs_NULL/expectedResults.json
+++ b/test-fixtures/index/300_CD_vs_NULL/expectedResults.json
@@ -1,0 +1,7 @@
+{
+    "action": "merge",
+    "preference": {
+        "name": "both records passed all tests, but no winner was found",
+        "value": true
+    }
+}

--- a/test-fixtures/index/300_CD_vs_NULL/inputRecordA.json
+++ b/test-fixtures/index/300_CD_vs_NULL/inputRecordA.json
@@ -1,0 +1,65 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "022",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0794-7348"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001275159"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+    "subfields": [
+      { "code": "a", "value": "2 CD-äänilevyä (määrä ei merkkaa mitään) +"},
+      { "code": "e", "value": "1 LP-äänilevy ei meinaa tässä mitään"}
+
+    ]
+  }
+  ]
+}

--- a/test-fixtures/index/300_CD_vs_NULL/inputRecordB.json
+++ b/test-fixtures/index/300_CD_vs_NULL/inputRecordB.json
@@ -1,0 +1,42 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+      "subfields": [
+        { "code": "a", "value": "nide (666 sivua) +"},
+        { "code": "e", "value": "2 CD-äänilevyä ja 1 LP-äänilevy ei meinaa tässä mitään"}
+      ]
+    }
+  ]
+}

--- a/test-fixtures/index/300_CD_vs_NULL/metadata.json
+++ b/test-fixtures/index/300_CD_vs_NULL/metadata.json
@@ -1,0 +1,4 @@
+{
+    "description": "300$a CD vs NULL",
+    "enabled": true
+}

--- a/test-fixtures/index/300_LP_vs_CD/expectedResults.json
+++ b/test-fixtures/index/300_LP_vs_CD/expectedResults.json
@@ -1,0 +1,5 @@
+{
+    "action": false,
+    "message": "audio sanity check (validation only) failed",
+    "preference": false
+}

--- a/test-fixtures/index/300_LP_vs_CD/inputRecordA.json
+++ b/test-fixtures/index/300_LP_vs_CD/inputRecordA.json
@@ -1,0 +1,63 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "022",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0794-7348"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001275159"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+    "subfields": [
+      { "code": "a", "value": "1 LP-äänilevy"}
+    ]
+  }
+  ]
+}

--- a/test-fixtures/index/300_LP_vs_CD/inputRecordB.json
+++ b/test-fixtures/index/300_LP_vs_CD/inputRecordB.json
@@ -1,0 +1,41 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+      "subfields": [
+        { "code": "a", "value": "1 CD-ljudskiva"}
+      ]
+    }
+  ]
+}

--- a/test-fixtures/index/300_LP_vs_CD/metadata.json
+++ b/test-fixtures/index/300_LP_vs_CD/metadata.json
@@ -1,0 +1,4 @@
+{
+    "description": "300$a CD vs LP",
+    "enabled": true
+}


### PR DESCRIPTION
Eli muutos blokkaa mergen, jos 300-kentän (physical description) $a-osakentän tiedot ovat ristiridassa aineiston (toinen on kallellallan CD:isiin ja toinen LP:isiin). Ratkaisu on vähän minimalistinen proto, ja hyväksyessä tätä kannattaisi pohtia seuraavien asioiden käsittelyä mukaanottoa:

- Ratkaisu ei ota kantaa levyjen määrään (1 LP-äänilevyä vs 2 LP-äänilevyä menee läpi)
- Käytetään MTS:n mukaista muotoa CD-äänilevyä. Virheellinen CD-levy (joka on datalle) on yleinen. CD-levyä ei tueta
- Suomi vs ruotsi ei aiheuta ongelmia. Tukee /(äänilevy|ljudskiv)/-muotoja, en tiedä mikä olis _ääni_levy englanniksi, eikä MTS:kään auta.
- CD vs NULL menee myös läpi, vaatii ristiriidan failatakseen

Noi kaksi ekaa ranskalaista viivaa on tietty korkeintaan nice-to-have osastoa, eivätkä ne liity alkuperäsieen ongelmaan, ja eivät myöskään estä tämän käyttöönottoa tällaisenaankin