### PR TITLE
Mra 185

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ import {check005, check008} from './controlFields';
 import {compareRecordsPartSetFeatures} from './partsAndSets';
 import {performAudioSanityCheck} from './sanityCheckAudio';
 import {performDaisySanityCheck} from './sanityCheckDaisy';
+import {performDvdSanityCheck} from './sanityCheckDvd';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:index');
 
@@ -86,6 +87,7 @@ const comparisonTasks = [ // NB! These are/should be in priority order!
   {'description': '005 timestamp test (validation and preference)', 'function': check005},
   {'description': 'audio sanity check (validation only)', 'function': performAudioSanityCheck},
   {'description': 'Daisy sanity check (validation only)', 'function': performDaisySanityCheck},
+  {'description': 'DVD vs Blu-Ray sanity check (validation only)', 'function': performDvdSanityCheck},
   {'description': 'Parts vs checks test (validation)', 'function': compareRecordsPartSetFeatures}
 ];
 

--- a/src/sanityCheckDvd.js
+++ b/src/sanityCheckDvd.js
@@ -1,0 +1,118 @@
+/**
+*
+* @licstart  The following is the entire license notice for the JavaScript code in this file.
+*
+* Melinda record match validator modules for Javascript
+*
+* Copyright (C) 2021-2022 University Of Helsinki (The National Library Of Finland)
+*
+* This file is part of melinda-record-match-validator
+*
+* melinda-record-match-validator program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* melinda-record-match-validator is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* @licend  The above is the entire license notice
+* for the JavaScript code in this file.
+*
+*/
+
+//import createDebugLogger from 'debug';
+//import {nvdebug} from './utils';
+
+//const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:physicalDescription');
+
+function physicalDescriptionContainsDvdVideoLevy(fields300) {
+  return fields300.some(field => field.subfields.some(subfield => containsDvdVideolevy(subfield)));
+
+  function containsDvdVideolevy(subfield) {
+    if (subfield.code !== 'a') {
+      return false;
+    }
+
+    if (subfield.value.match(/DVD-video(?:levy|skiv)/ui)) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+function physicalDescriptionContainsBluRayVideolevy(fields300) {
+  return fields300.some(field => field.subfields.some(subfield => containsBluRayVideolevy(subfield)));
+
+  function containsBluRayVideolevy(subfield) {
+    if (subfield.code !== 'a') {
+      return false;
+    }
+    // Surprisingly we have 288 Blu-Ray-äänilevy entries, so plain Blu-Ray won't do
+    if (subfield.value.match(/Blu-?Ray-video(?:levy|skiv)/ui)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function isDvdVideolevy(record) {
+  const fields007 = record.get(/^007$/u);
+  if (fields007.some(field => field.value.match(/^v...v/u))) {
+    return true;
+  }
+
+  const fields = record.get(/^300$/u);
+  if (physicalDescriptionContainsDvdVideoLevy(fields)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isBluRayVideolevy(record) {
+  const fields007 = record.get(/^007$/u);
+  if (fields007.some(field => field.value.match(/^v...s/u))) {
+    return true;
+  }
+
+  const fields300 = record.get(/^300$/u);
+  if (physicalDescriptionContainsBluRayVideolevy(fields300)) {
+    return true;
+  }
+
+  return false;
+}
+
+function getPhysicalDescription(record) {
+  return {
+    containsDvdVideolevy: isDvdVideolevy(record),
+    containsBluRayVideolevy: isBluRayVideolevy(record)
+  };
+}
+
+export function performDvdSanityCheck({record1, record2}) {
+  const results1 = getPhysicalDescription(record1);
+  const results2 = getPhysicalDescription(record2);
+
+  // NB! This won't fail if one 300$a has DVD-videolevy and the other one does not.
+  // This only fails if one is DVD and the other is Blu-Ray.
+  const checkDvd = results1.containsDvdVideolevy || results2.containsDvdVideolevy;
+  const checkBluRay = results1.containsBluRayVideolevy || results2.containsBluRayVideolevy;
+
+  if (checkDvd && results1.containsDvdVideolevy !== results2.containsDvdVideolevy) {
+    return false;
+  }
+
+  if (checkBluRay && results1.containsBluRayVideolevy !== results2.containsBluRayVideolevy) {
+    return false;
+  }
+
+  return true;
+}

--- a/test-fixtures/index/007_BluRay_vs_007_DVD/expectedResults.json
+++ b/test-fixtures/index/007_BluRay_vs_007_DVD/expectedResults.json
@@ -1,0 +1,5 @@
+{
+    "action": false,
+    "message": "DVD vs Blu-Ray sanity check (validation only) failed",
+    "preference": false
+}

--- a/test-fixtures/index/007_BluRay_vs_007_DVD/inputRecordA.json
+++ b/test-fixtures/index/007_BluRay_vs_007_DVD/inputRecordA.json
@@ -1,0 +1,67 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "007",
+      "value": "v|||s||||"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "022",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0794-7348"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001275159"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+    "subfields": [
+      { "code": "a", "value": "Random noise"}
+    ]
+  }
+  ]
+}

--- a/test-fixtures/index/007_BluRay_vs_007_DVD/inputRecordB.json
+++ b/test-fixtures/index/007_BluRay_vs_007_DVD/inputRecordB.json
@@ -1,0 +1,40 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "007",
+      "value": "v|||v||||"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/index/007_BluRay_vs_007_DVD/metadata.json
+++ b/test-fixtures/index/007_BluRay_vs_007_DVD/metadata.json
@@ -1,0 +1,4 @@
+{
+    "description": "007 Blu-Ray vs 007 DVD: fail",
+    "enabled": true
+}

--- a/test-fixtures/index/300_CD_vs_007_CD/metadata.json
+++ b/test-fixtures/index/300_CD_vs_007_CD/metadata.json
@@ -1,4 +1,4 @@
 {
-    "description": "300$a CD vs LP",
+    "description": "300$a CD vs 007 CD",
     "enabled": true
 }

--- a/test-fixtures/index/300_DVD_vs_007_DVD/expectedResults.json
+++ b/test-fixtures/index/300_DVD_vs_007_DVD/expectedResults.json
@@ -1,0 +1,7 @@
+{
+    "action": "merge",
+    "preference": {
+        "name": "both records passed all tests, but no winner was found",
+        "value": true
+    }
+}

--- a/test-fixtures/index/300_DVD_vs_007_DVD/inputRecordA.json
+++ b/test-fixtures/index/300_DVD_vs_007_DVD/inputRecordA.json
@@ -1,0 +1,63 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "022",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0794-7348"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)001275159"
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    },
+    { "tag": "300", "ind1": " ", "ind2": " ",
+    "subfields": [
+      { "code": "a", "value": "1 DVD-videolevy"}
+    ]
+  }
+  ]
+}

--- a/test-fixtures/index/300_DVD_vs_007_DVD/inputRecordB.json
+++ b/test-fixtures/index/300_DVD_vs_007_DVD/inputRecordB.json
@@ -1,0 +1,40 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "001275158"
+    },
+    {
+      "tag": "003",
+      "value": "FI-MELINDA"
+    },
+    {
+      "tag": "005",
+      "value": "20201104004608.0"
+    },
+    {
+      "tag": "007",
+      "value": "v|||v||||"
+    },
+    {
+      "tag": "008",
+      "value": "010101c19879999nr |||p| ||||||||||0eng|c"
+    },
+    {
+      "tag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "African dental journal /"
+        },
+        {
+          "code": "c",
+          "value": "Federation of African Dental Associations, FADA."
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/index/300_DVD_vs_007_DVD/metadata.json
+++ b/test-fixtures/index/300_DVD_vs_007_DVD/metadata.json
@@ -1,0 +1,4 @@
+{
+    "description": "300$a CD vs 007 DVD",
+    "enabled": true
+}


### PR DESCRIPTION
Validation only -testi DVD-videolevy vs Blu-Ray-videolevy. Käytännössä samanlainen rakenne kuin CD vs LP -tapauksessa.

Tarkistukset: kentät 300 ja 007.

DVD:lle ja Blu-Raylle oli olemassa videolevyn myös äänilevy-pääte metatietosanastossa, joten kirjoitin 300-kentän niuhommaksi kuin olisin ehkä halunnut.