### PR TITLE
Met439

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "2.0.8-alpha.1",
+  "version": "2.0.8-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/melinda-record-match-validator",
-      "version": "2.0.8-alpha.1",
+      "version": "2.0.8-alpha.2",
       "license": "LGPL-3.0+",
       "dependencies": {
         "@natlibfi/marc-record": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@natlibfi/marc-record": "^8.0.0",
         "@natlibfi/melinda-commons": "^13.0.7",
         "debug": "^4.3.4",
+        "isbn3": "^1.1.41",
         "moment": "^2.29.4"
       },
       "devDependencies": {
@@ -5059,6 +5060,19 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
+    },
+    "node_modules/isbn3": {
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.43.tgz",
+      "integrity": "sha512-RFRg0DILq6FG9O7oITmH0tUo5i5Ao3Wth2ldFHNwi5GVXKX6LbHqIvOekeEwZty/lD0RHoTgUqSlEShwa86oiw==",
+      "bin": {
+        "isbn": "bin/isbn",
+        "isbn-audit": "bin/isbn-audit",
+        "isbn-checksum": "bin/isbn-checksum"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@natlibfi/marc-record": "^7.3.1",
         "@natlibfi/melinda-commons": "^13.0.6",
         "debug": "^4.3.4",
+        "isbn3": "^1.1.41",
         "moment": "^2.29.4"
       },
       "devDependencies": {
@@ -4724,6 +4725,19 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
+    },
+    "node_modules/isbn3": {
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.41.tgz",
+      "integrity": "sha512-swPNNQP5No3L0fkD5OofDJ4uuMUjtX+Nr/UT7M8XF+uPcv4bz0GPQo4+SL0jGsaaT48F4YQrLRLrQhPRPvAhOQ==",
+      "bin": {
+        "isbn": "bin/isbn",
+        "isbn-audit": "bin/isbn-audit",
+        "isbn-checksum": "bin/isbn-checksum"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,30 +103,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-      "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
+      "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
-      "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
+      "integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.22.20",
         "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.15",
+        "@babel/parser": "^7.22.16",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15",
+        "@babel/traverse": "^7.22.20",
+        "@babel/types": "^7.22.19",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -329,16 +329,16 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.15.tgz",
-      "integrity": "sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.20.tgz",
+      "integrity": "sha512-dLT7JVWIUUxKOs1UnJUBR3S70YK+pKX6AbJgB2vMIvEkZkrfJDbYDJesnPshtKV4LhDOR3Oc5YULeDizRek+5A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.15"
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -369,14 +369,14 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.9.tgz",
-      "integrity": "sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
+      "integrity": "sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-wrap-function": "^7.22.9"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-wrap-function": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -386,13 +386,13 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
-      "integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
+      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
         "@babel/helper-optimise-call-expression": "^7.22.5"
       },
       "engines": {
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -466,14 +466,14 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.10.tgz",
-      "integrity": "sha512-OnMhjWjuGYtdoO3FmsEFWvBStBAe2QOgwOLsLNDjN+aaiMD8InJk1/O3HSD8lkqTjCgg5YI34Tz15KNNA3p+nQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
+      "integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-function-name": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.10"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.22.19"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -494,12 +494,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@babel/node": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.15.tgz",
-      "integrity": "sha512-DCHvKYVAC8w2Tvt2fgyyYteIwAEHejbVlBU1GlcBXFDEcdWqsADnK1tD/vgrCbsk/rt0tkgpWAiYaJAPR7PKfg==",
+      "version": "7.22.19",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.19.tgz",
+      "integrity": "sha512-VsKSO9aEHdO16NdtqkJfrXZ9Sxlna1BVnBbToWr1KGdI3cyIk6KqOoa8mWvpK280lJDOwJqxvnl994KmLhq1Yw==",
       "dev": true,
       "dependencies": {
         "@babel/register": "^7.22.15",
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.15.tgz",
-      "integrity": "sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA==",
+      "version": "7.22.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
+      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1594,12 +1594,12 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.15.tgz",
-      "integrity": "sha512-tZFHr54GBkHk6hQuVA8w4Fmq+MSPsfvMG0vPnOYyTnJpyfMqybL8/MbNCPRT9zc2KBO2pe4tq15g6Uno4Jpoag==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.20.tgz",
+      "integrity": "sha512-11MY04gGC4kSzlPHRfvVkNAZhUxOvm7DCJ37hPDnUENwe06npjIRAfInEMTGSb4LZK5ZgDFkv5hw0lGebHeTyg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
+        "@babel/compat-data": "^7.22.20",
         "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.15",
@@ -1673,7 +1673,7 @@
         "@babel/plugin-transform-unicode-regex": "^7.22.5",
         "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.22.19",
         "babel-plugin-polyfill-corejs2": "^0.4.5",
         "babel-plugin-polyfill-corejs3": "^0.8.3",
         "babel-plugin-polyfill-regenerator": "^0.5.2",
@@ -1753,19 +1753,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.15.tgz",
-      "integrity": "sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
+      "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
-        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15",
+        "@babel/parser": "^7.22.16",
+        "@babel/types": "^7.22.19",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1774,13 +1774,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.15.tgz",
-      "integrity": "sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==",
+      "version": "7.22.19",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
+      "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.15",
+        "@babel/helper-validator-identifier": "^7.22.19",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1815,9 +1815,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
-      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
+      "integrity": "sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1892,9 +1892,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
-      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2160,15 +2160,15 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -2796,9 +2796,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001527",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001527.tgz",
-      "integrity": "sha512-YkJi7RwPgWtXVSgK4lG9AHH57nSzvvOp9MesgXmw4Q7n0C3H04L0foHqfxcmSAm5AcWb8dW9AYj2tR7/5GnddQ==",
+      "version": "1.0.30001535",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001535.tgz",
+      "integrity": "sha512-48jLyUkiWFfhm/afF7cQPqPjaUmSraEhK4j+FCTJpgnGGEZHqyLe3hmWH7lIooZdSzXL0ReMvHz0vKDoTBsrwg==",
       "dev": true,
       "funding": [
         {
@@ -2974,9 +2974,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.1.tgz",
-      "integrity": "sha512-lqufgNn9NLnESg5mQeYsxQP5w7wrViSj0jr/kv6ECQiByzQkrn1MKvV0L3acttpDqfQrHLwr2KCMgX5b8X+lyQ==",
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
+      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -2985,9 +2985,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.32.1.tgz",
-      "integrity": "sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==",
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.32.2.tgz",
+      "integrity": "sha512-+GjlguTDINOijtVRUxrQOv3kfu9rl+qPNdX2LTbJ/ZyVTuxK+ksVSAGX1nHstu4hrv1En/uPTtWgq2gI5wt4AQ==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.21.10"
@@ -3095,12 +3095,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "node_modules/define-data-property": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
+      "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
       "dev": true,
       "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -3145,9 +3160,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.508",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg==",
+      "version": "1.4.523",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.523.tgz",
+      "integrity": "sha512-9AreocSUWnzNtvLcbpng6N+GkXnCcBR80IQkxRC9Dfdyg4gaWNUPBujAHUpKkiUkoSoR9UlhA4zD/IgBklmhzg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3156,18 +3171,18 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/es-abstract": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
-      "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
+      "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.2",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.5",
+        "function.prototype.name": "^1.1.6",
         "get-intrinsic": "^1.2.1",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
@@ -3183,23 +3198,23 @@
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.10",
+        "is-typed-array": "^1.1.12",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
-        "safe-array-concat": "^1.0.0",
+        "regexp.prototype.flags": "^1.5.1",
+        "safe-array-concat": "^1.0.1",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.7",
-        "string.prototype.trimend": "^1.0.6",
-        "string.prototype.trimstart": "^1.0.6",
+        "string.prototype.trim": "^1.2.8",
+        "string.prototype.trimend": "^1.0.7",
+        "string.prototype.trimstart": "^1.0.7",
         "typed-array-buffer": "^1.0.0",
         "typed-array-byte-length": "^1.0.0",
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.10"
+        "which-typed-array": "^1.1.11"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3269,16 +3284,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
-      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.48.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/js": "8.49.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.12.4",
@@ -3878,9 +3893,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "node_modules/for-each": {
@@ -6228,9 +6243,9 @@
       "dev": true
     },
     "node_modules/regenerate-unicode-properties": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
-      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
+      "integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
       "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -6255,14 +6270,14 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
-        "functions-have-names": "^1.2.3"
+        "set-function-name": "^2.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6336,9 +6351,9 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
+      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -6489,6 +6504,20 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -6681,14 +6710,14 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6698,14 +6727,14 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "2.0.8-alpha.1",
+  "version": "2.0.8-alpha.2",
   "description": "Validates if two records matched by melinda-record-matching can be merged and sets merge priority",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@natlibfi/marc-record": "^7.3.1",
     "@natlibfi/melinda-commons": "^13.0.6",
     "debug": "^4.3.4",
+    "isbn3": "^1.1.41",
     "moment": "^2.29.4"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ import {compareRecordsPartSetFeatures} from './partsAndSets';
 import {performAudioSanityCheck} from './sanityCheckAudio';
 import {performDaisySanityCheck} from './sanityCheckDaisy';
 import {performDvdSanityCheck} from './sanityCheckDvd';
+import {performIsbnQualifierCheck} from './sanityCheckIsbnQualifer';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:index');
 
@@ -88,6 +89,7 @@ const comparisonTasks = [ // NB! These are/should be in priority order!
   {'description': 'audio sanity check (validation only)', 'function': performAudioSanityCheck},
   {'description': 'Daisy sanity check (validation only)', 'function': performDaisySanityCheck},
   {'description': 'DVD vs Blu-Ray sanity check (validation only)', 'function': performDvdSanityCheck},
+  {'description': 'ISBN qualifier sanity check (validation only)', 'function': performIsbnQualifierCheck},
   {'description': 'Parts vs checks test (validation)', 'function': compareRecordsPartSetFeatures}
 ];
 

--- a/src/sanityCheckIsbnQualifer.js
+++ b/src/sanityCheckIsbnQualifer.js
@@ -1,0 +1,98 @@
+/**
+*
+* @licstart  The following is the entire license notice for the JavaScript code in this file.
+*
+* Melinda record match validator modules for Javascript
+*
+* Copyright (C) 2021-2023 University Of Helsinki (The National Library Of Finland)
+*
+* This file is part of melinda-record-match-validator
+*
+* melinda-record-match-validator program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* melinda-record-match-validator is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* @licend  The above is the entire license notice
+* for the JavaScript code in this file.
+*
+*/
+
+//import createDebugLogger from 'debug';
+//import {nvdebug} from './utils';
+
+//const debug = createDebugLogger('@natlibfi/melinda-record-match-validator:sanityCheckIsbnQualifier');
+
+
+function mapQualifier(value) {
+  // Try to map 020$q value to a group
+  if (value.match(/epub/iu)) {
+    return 'EPUB';
+  }
+  if (value.match(/pdf/iu)) {
+    return 'PDF';
+  }
+  if (value.match(/^(?:hft|häftad|mjuka pärmar|nid|paperback|pehmeäkantinen)/ui)) {
+    return 'PEHMEÄKANTINEN';
+  }
+  if (value.match(/^(?:hard.?cover|hårda pärmar|kovakantinen|sid)/ui)) {
+    return 'KOVAKANTINEN';
+  }
+  return undefined;
+
+}
+
+function fieldsShareIsbn(field1, field2) {
+  const subfields1 = field1.subfields.filter(sf => sf.code === 'a');
+  const subfields2 = field2.subfields.filter(sf => sf.code === 'a');
+
+  return subfields1.some(sf1 => subfields2.some(sf2 => sf1.value === sf2.value));
+
+}
+
+function hasConflictingQualifierTypes(type1, type2) {
+  return type1 !== undefined && type2 !== undefined && type1 !== type2;
+}
+
+function fieldHaveConflictingQualifiers(field1, field2) {
+  const qualifierTypes1 = field1.subfields.filter(sf => sf.code === 'q').map(sf => mapQualifier(sf.value));
+  const qualifierTypes2 = field2.subfields.filter(sf => sf.code === 'q').map(sf => mapQualifier(sf.value));
+
+  return qualifierTypes1.some(type1 => qualifierTypes2.some(type2 => hasConflictingQualifierTypes(type1, type2)));
+}
+
+function hasConflinctingQualifier(field, otherFields) {
+  const relevantOtherFields = otherFields.filter(f => fieldsShareIsbn(field, otherFields));
+  if (relevantOtherFields.length === 0) {
+    return false; // No shared ISBNs -> no conflict
+  }
+  return relevantOtherFields.some(field2 => fieldHaveConflictingQualifiers(field, field2));
+}
+
+function isRelevantField(field) {
+  if (field.tag !== '020'){
+    return false;
+  }
+
+  return field.subfields.some(sf => sf.code === 'a') && field.subfields.some(sf => sf.code === 'q'); 
+}
+
+
+export function performIsbnQualifiercheck({record1, record2}) {
+  const fields1 = record1.fields.filter(f => isRelevantField(f));
+  const fields2 = record2.fields.filter(f => isRelevantField(f));
+  if (fields1.length === 0 || fields2.length === 0) {
+    return true;
+  }
+
+  return fields1.some(f => !hasConflinctingQualifier(f, fields2));
+}
+

--- a/src/sanityCheckIsbnQualifer.js
+++ b/src/sanityCheckIsbnQualifer.js
@@ -70,7 +70,7 @@ function fieldHaveConflictingQualifiers(field1, field2) {
 }
 
 function hasConflinctingQualifier(field, otherFields) {
-  const relevantOtherFields = otherFields.filter(f => fieldsShareIsbn(field, otherFields));
+  const relevantOtherFields = otherFields.filter(f => fieldsShareIsbn(f, otherFields));
   if (relevantOtherFields.length === 0) {
     return false; // No shared ISBNs -> no conflict
   }
@@ -78,11 +78,11 @@ function hasConflinctingQualifier(field, otherFields) {
 }
 
 function isRelevantField(field) {
-  if (field.tag !== '020'){
+  if (field.tag !== '020') {
     return false;
   }
 
-  return field.subfields.some(sf => sf.code === 'a') && field.subfields.some(sf => sf.code === 'q'); 
+  return field.subfields.some(sf => sf.code === 'a') && field.subfields.some(sf => sf.code === 'q');
 }
 
 

--- a/src/sanityCheckIsbnQualifer.js
+++ b/src/sanityCheckIsbnQualifer.js
@@ -70,7 +70,7 @@ function fieldHaveConflictingQualifiers(field1, field2) {
 }
 
 function hasConflinctingQualifier(field, otherFields) {
-  const relevantOtherFields = otherFields.filter(f => fieldsShareIsbn(f, otherFields));
+  const relevantOtherFields = otherFields.filter(field2 => fieldsShareIsbn(field, field2));
   if (relevantOtherFields.length === 0) {
     return false; // No shared ISBNs -> no conflict
   }
@@ -86,7 +86,7 @@ function isRelevantField(field) {
 }
 
 
-export function performIsbnQualifiercheck({record1, record2}) {
+export function performIsbnQualifierCheck({record1, record2}) {
   const fields1 = record1.fields.filter(f => isRelevantField(f));
   const fields2 = record2.fields.filter(f => isRelevantField(f));
   if (fields1.length === 0 || fields2.length === 0) {

--- a/test-fixtures/index/020_bad_qualifiers/expectedResults.json
+++ b/test-fixtures/index/020_bad_qualifiers/expectedResults.json
@@ -1,0 +1,5 @@
+{
+    "action": false,
+    "preference": false,
+    "message": "ISBN qualifier sanity check (validation only) failed"
+}

--- a/test-fixtures/index/020_bad_qualifiers/inputRecordA.json
+++ b/test-fixtures/index/020_bad_qualifiers/inputRecordA.json
@@ -1,0 +1,17 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields" : [
+    { "tag": "001", "value": "001275158" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20201104004608.0" },
+    { "tag": "008", "value": "010101c19879999nr |||p| ||||||||||0eng|c" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "0000000002" },
+      { "code": "q", "value": "PDF" }
+    ]},
+    { "tag": "245", "ind1": "0", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "African dental journal /" },
+        { "code": "c", "value": "Federation of African Dental Associations, FADA." }
+    ]}
+  ]
+}

--- a/test-fixtures/index/020_bad_qualifiers/inputRecordB.json
+++ b/test-fixtures/index/020_bad_qualifiers/inputRecordB.json
@@ -1,0 +1,17 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields" : [
+    { "tag": "001", "value": "001275158" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20201104004608.0" },
+    { "tag": "008", "value": "010101c19879999nr |||p| ||||||||||0eng|c" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "0000000002" },
+        { "code": "q", "value": "(epub)" }
+      ]},
+    { "tag": "245", "ind1": "0", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "African dental journal /" },
+        { "code": "c", "value": "Federation of African Dental Associations, FADA." }
+    ]}
+  ]
+}

--- a/test-fixtures/index/020_bad_qualifiers/metadata.json
+++ b/test-fixtures/index/020_bad_qualifiers/metadata.json
@@ -1,4 +1,4 @@
 {
-    "description": "B has SID field, and A does not: B wins",
+    "description": "Identical ISBN, $q conflict: PDF vs epub",
     "enabled": true
 }

--- a/test-fixtures/index/020_bad_qualifiers/metadata.json
+++ b/test-fixtures/index/020_bad_qualifiers/metadata.json
@@ -1,0 +1,4 @@
+{
+    "description": "B has SID field, and A does not: B wins",
+    "enabled": true
+}

--- a/test-fixtures/index/020_bad_qualifiers_10_vs_13/expectedResults.json
+++ b/test-fixtures/index/020_bad_qualifiers_10_vs_13/expectedResults.json
@@ -1,0 +1,5 @@
+{
+    "action": false,
+    "preference": false,
+    "message": "ISBN qualifier sanity check (validation only) failed"
+}

--- a/test-fixtures/index/020_bad_qualifiers_10_vs_13/inputRecordA.json
+++ b/test-fixtures/index/020_bad_qualifiers_10_vs_13/inputRecordA.json
@@ -1,0 +1,17 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields" : [
+    { "tag": "001", "value": "001275158" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20201104004608.0" },
+    { "tag": "008", "value": "010101c19879999nr |||p| ||||||||||0eng|c" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978-0-231-70152-5" },
+      { "code": "q", "value": "PDF" }
+    ]},
+    { "tag": "245", "ind1": "0", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "African dental journal /" },
+        { "code": "c", "value": "Federation of African Dental Associations, FADA." }
+    ]}
+  ]
+}

--- a/test-fixtures/index/020_bad_qualifiers_10_vs_13/inputRecordB.json
+++ b/test-fixtures/index/020_bad_qualifiers_10_vs_13/inputRecordB.json
@@ -1,0 +1,17 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields" : [
+    { "tag": "001", "value": "001275158" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20201104004608.0" },
+    { "tag": "008", "value": "010101c19879999nr |||p| ||||||||||0eng|c" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "0-231-70152-7" },
+        { "code": "q", "value": "(epub)" }
+      ]},
+    { "tag": "245", "ind1": "0", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "African dental journal /" },
+        { "code": "c", "value": "Federation of African Dental Associations, FADA." }
+    ]}
+  ]
+}

--- a/test-fixtures/index/020_bad_qualifiers_10_vs_13/metadata.json
+++ b/test-fixtures/index/020_bad_qualifiers_10_vs_13/metadata.json
@@ -1,0 +1,5 @@
+{
+    "description": "Same ID written differently (10 vs 13 digits, hyphenation) can still fail in $q",
+    "enabled": true,
+    "only": true
+}

--- a/test-fixtures/index/020_bad_qualifiers_10_vs_13/metadata.json
+++ b/test-fixtures/index/020_bad_qualifiers_10_vs_13/metadata.json
@@ -1,5 +1,5 @@
 {
     "description": "Same ID written differently (10 vs 13 digits, hyphenation) can still fail in $q",
     "enabled": true,
-    "only": true
+    "only": false
 }

--- a/test-fixtures/index/020_good_qualifiers/expectedResults.json
+++ b/test-fixtures/index/020_good_qualifiers/expectedResults.json
@@ -1,0 +1,7 @@
+{
+    "action": "merge",
+    "preference": {
+        "name": "both records passed all tests, but no winner was found",
+        "value": true
+    }
+}

--- a/test-fixtures/index/020_good_qualifiers/inputRecordA.json
+++ b/test-fixtures/index/020_good_qualifiers/inputRecordA.json
@@ -1,0 +1,21 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields" : [
+    { "tag": "001", "value": "001275158" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20201104004608.0" },
+    { "tag": "008", "value": "010101c19879999nr |||p| ||||||||||0eng|c" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "0000000001" },
+      { "code": "q", "value": "sidottu" }
+    ]},
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "0000000002" },
+      { "code": "q", "value": "PDF" }
+    ]},
+    { "tag": "245", "ind1": "0", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "African dental journal /" },
+        { "code": "c", "value": "Federation of African Dental Associations, FADA." }
+    ]}
+  ]
+}

--- a/test-fixtures/index/020_good_qualifiers/inputRecordB.json
+++ b/test-fixtures/index/020_good_qualifiers/inputRecordB.json
@@ -1,0 +1,20 @@
+{
+  "leader": "01092cas a22003494i 4500",
+  "fields" : [
+    { "tag": "001", "value": "001275158" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20201104004608.0" },
+    { "tag": "008", "value": "010101c19879999nr |||p| ||||||||||0eng|c" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "0000000001" },
+        { "code": "q", "value": "kovakantinen" }
+    ]},
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "0000000002" }
+      ]},
+    { "tag": "245", "ind1": "0", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "African dental journal /" },
+        { "code": "c", "value": "Federation of African Dental Associations, FADA." }
+    ]}
+  ]
+}

--- a/test-fixtures/index/020_good_qualifiers/metadata.json
+++ b/test-fixtures/index/020_good_qualifiers/metadata.json
@@ -1,0 +1,4 @@
+{
+    "description": "B has SID field, and A does not: B wins",
+    "enabled": true
+}

--- a/test-fixtures/index/020_good_qualifiers/metadata.json
+++ b/test-fixtures/index/020_good_qualifiers/metadata.json
@@ -1,4 +1,4 @@
 {
-    "description": "B has SID field, and A does not: B wins",
+    "description": "identical 020$a isbns, $q's with missing values or values that look different but mean same",
     "enabled": true
 }


### PR DESCRIPTION
Fixes MET-439. Not only PDF vs EPUB, but also kovakantinen/sidottu vs pehmeäkantinen/nidottu. Easily extendable to other groups of $q values

Not perfect: funny $q values induce false positives/negatives, but then we have crappy data anyway. 

Oops: lacks isbn normalization (both hyphenation and 10- vs 13-digit values... Will add. But let's keep this here anyway.