### PR TITLE
Fix 773w bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.57.1",
         "mocha": "^11.1.0",
-        "nodemon": "^3.1.9",
+        "nodemon": "^3.1.10",
         "nyc": "^17.1.0"
       },
       "engines": {
@@ -2908,9 +2908,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001714",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz",
-      "integrity": "sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==",
+      "version": "1.0.30001715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
       "dev": true,
       "funding": [
         {
@@ -3385,9 +3385,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.137.tgz",
-      "integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA==",
+      "version": "1.5.144",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.144.tgz",
+      "integrity": "sha512-eJIaMRKeAzxfBSxtjYnoIAw/tdD6VIH6tHBZepZnAbE3Gyqqs5mGN87DvcldPUbVkIljTK8pY0CMcUljP64lfQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "2.3.2-alpha.1",
+  "version": "2.3.2-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/melinda-record-match-validator",
-      "version": "2.3.2-alpha.1",
+      "version": "2.3.2-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@natlibfi/marc-record": "^9.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "2.3.1",
+  "version": "2.3.2-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/melinda-record-match-validator",
-      "version": "2.3.1",
+      "version": "2.3.2-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@natlibfi/marc-record": "^9.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "2.3.2-alpha.1",
+  "version": "2.3.2-alpha.2",
   "description": "Validates if two records matched by melinda-record-matching can be merged and sets merge priority",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/melinda-record-match-validator",
-  "version": "2.3.1",
+  "version": "2.3.2-alpha.1",
   "description": "Validates if two records matched by melinda-record-matching can be merged and sets merge priority",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",
     "mocha": "^11.1.0",
-    "nodemon": "^3.1.9",
+    "nodemon": "^3.1.10",
     "nyc": "^17.1.0"
   },
   "eslintConfig": {

--- a/src/field773.js
+++ b/src/field773.js
@@ -35,7 +35,8 @@ function getX73(record, paramTag) {
     if (wSubfields.length > 0) {
       return wSubfields;
     }
-    return getDefaultMissValue();
+    return [];
+    //return getDefaultMissValue();
   }
 }
 
@@ -95,6 +96,10 @@ function compare773values(f773sA, f773sB) {
   }
 
   function acceptControlNumbers(nums1, nums2) {
+    // Check that nums1 && nums2 are not undefined
+    /*if (nums1 === undefined || nums2 === undefined) {
+      return true;
+    }*/
     return !(nums1.some(val => hasIdMismatch(val, nums2)) || nums2.some(val2 => hasIdMismatch(val2, nums1)));
   }
 

--- a/test-fixtures/collectRecordValues/14/expectedResults.json
+++ b/test-fixtures/collectRecordValues/14/expectedResults.json
@@ -1,0 +1,117 @@
+{
+  "245": {
+    "nameOfPartInSectionOfAWork": "undefined",
+    "numberOfPartInSectionOfAWork": "undefined",
+    "remainderOfTitle": "undefined",
+    "title": "Lippulaulu"
+  },
+"title": {
+    "f946Features": [],
+    "seriesFeatures": [],
+    "titleFeatures": {
+      "namesOfPartInSectionOfAWork": [],
+      "numbersOfPartInSectionOfAWork": [],
+      "remainderOfTitle": "undefined",
+      "title": "Lippulaulu"
+    }
+  },
+  "336": {
+    "types": [
+      "prm"
+    ]
+  },
+  "337": {
+    "types": [
+      "s"
+    ]
+  },
+  "338": {
+    "types": []
+  },
+  "773": [
+    {
+      "enumerationAndFirstPage": "undefined",
+      "recordControlNumbers": [
+        "(FI-MELINDA)015633197",
+        "(FI-Arto)54331"
+      ],
+      "relatedParts": "Raita 7",
+      "tag": "773"
+    }
+  ],
+  "000": {
+    "bibliographicLevel": {
+      "code": "a",
+      "level": "Monographic component part"
+    },
+    "encodingLevel": {
+      "code": "4",
+      "level": "Core level"
+    },
+    "prepublicationLevel": {
+      "code": "0",
+      "level": "Not a prepublication"
+    },
+    "typeOfRecord": {
+      "code": "j",
+      "level": "Musical sound recording"
+    }
+  },
+  "001": {
+    "isMelindaId": true,
+    "value": "015906014"
+  },
+  "005": "2020-08-06T15:20:53",
+  "008": {
+    "catalogingSource": {
+      "code": " ",
+      "level": "National bibliographical agency"
+    },
+    "formOfItem": {
+      "code": "|",
+      "form": "No attempt to code"
+    },
+    "publicationStatus": {
+      "code": "s",
+      "level": "Single known/probable date"
+    }
+  },
+  "042": [
+    "finbd"
+  ],
+  "CAT": {
+    "latest": {
+      "cataloger": "LOAD-FIX",
+      "time": "2020-08-06T15:20:00"
+    },
+    "otherCats": [
+      {
+        "cataloger": "LOAD-ID",
+        "time": "2019-08-31T01:14:00"
+      },
+      {
+        "cataloger": "LOAD-ID",
+        "time": "2019-07-13T00:07:00"
+      },
+      {
+        "cataloger": "LOAD-VIOLA",
+        "time": "2019-06-06T09:50:00"
+      }
+    ]
+  },
+  "LOW": [
+    "VIOLA",
+    "FIKKA"
+  ],
+  "SID": [
+    {
+      "database": "viola",
+      "id": "881913"
+    }
+  ],
+  "commonIdentifiers": {
+    "deleted": false,
+    "standardIdentifiers": [],
+    "title": "Lippulaulu"
+  }
+}

--- a/test-fixtures/collectRecordValues/14/expectedResults.json
+++ b/test-fixtures/collectRecordValues/14/expectedResults.json
@@ -31,10 +31,7 @@
   "773": [
     {
       "enumerationAndFirstPage": "undefined",
-      "recordControlNumbers": [
-        "(FI-MELINDA)015633197",
-        "(FI-Arto)54331"
-      ],
+      "recordControlNumbers": [],
       "relatedParts": "Raita 7",
       "tag": "773"
     }

--- a/test-fixtures/collectRecordValues/14/inputRecord.json
+++ b/test-fixtures/collectRecordValues/14/inputRecord.json
@@ -1,0 +1,119 @@
+{
+  "leader": "01410cja a22003854i 4500",
+  "fields" : [
+    { "tag": "001", "value": "015906014" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20200806152053.0" },
+    { "tag": "007", "value": "sd||||||||m||d" },
+    { "tag": "008", "value": "100120s2007    xx mrnn |||||||   | zxx| " },
+    { "tag": "035", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "881913" }
+    ]},
+    { "tag": "035", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "(FI-MELINDA)015906014" }
+    ]},
+    { "tag": "040", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "FI-NLD" }
+    ]},
+    { "tag": "042", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "finbd" }
+    ]},
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Kilpinen, Yrjö," },
+        { "code": "d", "value": "1892-1959," },
+        { "code": "e", "value": "säveltäjä." }
+    ]},
+    { "tag": "240", "ind1": "1", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "Lippulaulu" }
+    ]},
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "Lippulaulu." }
+    ]},
+    { "tag": "306", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "000155" }
+    ]},
+    { "tag": "336", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "esitetty musiikki" },
+        { "code": "b", "value": "prm" },
+        { "code": "2", "value": "rdacontent" }
+    ]},
+    { "tag": "337", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "audio" },
+        { "code": "b", "value": "s" },
+        { "code": "2", "value": "rdamedia" }
+    ]},
+    { "tag": "511", "ind1": "0", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Jääkäriprikaatin Jääkärikuoro, Jussi Juola (joht.), Lapin Sotilassoittokunta, Juha Tiensuu (joht.)." }
+    ]},
+    { "tag": "598", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "[Äänite]." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Laitinen, T.," },
+        { "code": "e", "value": "sanoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Juola, Jussi," },
+        { "code": "e", "value": "johtaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Tiensuu, Juha," },
+        { "code": "e", "value": "johtaja." }
+    ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Jääkäriprikaatin Jääkärikuoro," },
+        { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Lapin Sotilassoittokunta," },
+        { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "773", "ind1": "0", "ind2": " ", "subfields" : [
+        { "code": "7", "value": "nnjm" },
+        { "code": "w", "value": "12345" },
+        { "code": "t", "value": "Lauluja Lutolta ja Lapista. -" },
+        { "code": "d", "value": "[Kustannuspaikka tuntematon] : Luton Miesten Perinnetoimikunta, 2007. -" },
+        { "code": "h", "value": "1 CD-äänilevy. -" },
+        { "code": "o", "value": "Luton Miesten Perinnetoimikunta HMM1319-4. -" },
+        { "code": "g", "value": "Raita 7" }
+    ]},
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "c", "value": "881913" },
+        { "code": "b", "value": "viola" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-VIOLA" },
+        { "code": "b", "value": "20" },
+        { "code": "c", "value": "20190606" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "0950" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-ID" },
+        { "code": "b", "value": "00" },
+        { "code": "c", "value": "20190713" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "0007" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-ID" },
+        { "code": "b", "value": "00" },
+        { "code": "c", "value": "20190831" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "0114" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-FIX" },
+        { "code": "b", "value": "30" },
+        { "code": "c", "value": "20200806" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "1520" }
+    ]},
+    { "tag": "LOW", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "VIOLA" }
+    ]},
+    { "tag": "LOW", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "FIKKA" }
+    ]}
+  ]
+}

--- a/test-fixtures/collectRecordValues/14/metadata.json
+++ b/test-fixtures/collectRecordValues/14/metadata.json
@@ -1,0 +1,5 @@
+{
+    "description": "Should handle monographic component part with 773 $w that does not have a source prefix",
+    "skip": false,
+    "only": true
+}

--- a/test-fixtures/collectRecordValues/14/metadata.json
+++ b/test-fixtures/collectRecordValues/14/metadata.json
@@ -1,5 +1,5 @@
 {
     "description": "Should handle monographic component part with 773 $w that does not have a source prefix",
     "skip": false,
-    "only": true
+    "only": false
 }

--- a/test-fixtures/collectRecordValues/15/expectedResults.json
+++ b/test-fixtures/collectRecordValues/15/expectedResults.json
@@ -1,0 +1,114 @@
+{
+  "245": {
+    "nameOfPartInSectionOfAWork": "undefined",
+    "numberOfPartInSectionOfAWork": "undefined",
+    "remainderOfTitle": "undefined",
+    "title": "Lippulaulu"
+  },
+"title": {
+    "f946Features": [],
+    "seriesFeatures": [],
+    "titleFeatures": {
+      "namesOfPartInSectionOfAWork": [],
+      "numbersOfPartInSectionOfAWork": [],
+      "remainderOfTitle": "undefined",
+      "title": "Lippulaulu"
+    }
+  },
+  "336": {
+    "types": [
+      "prm"
+    ]
+  },
+  "337": {
+    "types": [
+      "s"
+    ]
+  },
+  "338": {
+    "types": []
+  },
+  "773": [
+    {
+      "enumerationAndFirstPage": "undefined",
+      "recordControlNumbers": [],
+      "relatedParts": "Raita 7",
+      "tag": "773"
+    }
+  ],
+  "000": {
+    "bibliographicLevel": {
+      "code": "a",
+      "level": "Monographic component part"
+    },
+    "encodingLevel": {
+      "code": "4",
+      "level": "Core level"
+    },
+    "prepublicationLevel": {
+      "code": "0",
+      "level": "Not a prepublication"
+    },
+    "typeOfRecord": {
+      "code": "j",
+      "level": "Musical sound recording"
+    }
+  },
+  "001": {
+    "isMelindaId": true,
+    "value": "015906014"
+  },
+  "005": "2020-08-06T15:20:53",
+  "008": {
+    "catalogingSource": {
+      "code": " ",
+      "level": "National bibliographical agency"
+    },
+    "formOfItem": {
+      "code": "|",
+      "form": "No attempt to code"
+    },
+    "publicationStatus": {
+      "code": "s",
+      "level": "Single known/probable date"
+    }
+  },
+  "042": [
+    "finbd"
+  ],
+  "CAT": {
+    "latest": {
+      "cataloger": "LOAD-FIX",
+      "time": "2020-08-06T15:20:00"
+    },
+    "otherCats": [
+      {
+        "cataloger": "LOAD-ID",
+        "time": "2019-08-31T01:14:00"
+      },
+      {
+        "cataloger": "LOAD-ID",
+        "time": "2019-07-13T00:07:00"
+      },
+      {
+        "cataloger": "LOAD-VIOLA",
+        "time": "2019-06-06T09:50:00"
+      }
+    ]
+  },
+  "LOW": [
+    "VIOLA",
+    "FIKKA"
+  ],
+  "SID": [
+    {
+      "database": "viola",
+      "id": "881913"
+    }
+  ],
+  "commonIdentifiers": {
+    "deleted": false,
+    "standardIdentifiers": [],
+    "title": "Lippulaulu"
+  }
+}

--- a/test-fixtures/collectRecordValues/15/inputRecord.json
+++ b/test-fixtures/collectRecordValues/15/inputRecord.json
@@ -1,0 +1,118 @@
+{
+  "leader": "01410cja a22003854i 4500",
+  "fields" : [
+    { "tag": "001", "value": "015906014" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20200806152053.0" },
+    { "tag": "007", "value": "sd||||||||m||d" },
+    { "tag": "008", "value": "100120s2007    xx mrnn |||||||   | zxx| " },
+    { "tag": "035", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "881913" }
+    ]},
+    { "tag": "035", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "(FI-MELINDA)015906014" }
+    ]},
+    { "tag": "040", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "FI-NLD" }
+    ]},
+    { "tag": "042", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "finbd" }
+    ]},
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Kilpinen, Yrjö," },
+        { "code": "d", "value": "1892-1959," },
+        { "code": "e", "value": "säveltäjä." }
+    ]},
+    { "tag": "240", "ind1": "1", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "Lippulaulu" }
+    ]},
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields" : [
+        { "code": "a", "value": "Lippulaulu." }
+    ]},
+    { "tag": "306", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "000155" }
+    ]},
+    { "tag": "336", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "esitetty musiikki" },
+        { "code": "b", "value": "prm" },
+        { "code": "2", "value": "rdacontent" }
+    ]},
+    { "tag": "337", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "audio" },
+        { "code": "b", "value": "s" },
+        { "code": "2", "value": "rdamedia" }
+    ]},
+    { "tag": "511", "ind1": "0", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Jääkäriprikaatin Jääkärikuoro, Jussi Juola (joht.), Lapin Sotilassoittokunta, Juha Tiensuu (joht.)." }
+    ]},
+    { "tag": "598", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "[Äänite]." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Laitinen, T.," },
+        { "code": "e", "value": "sanoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Juola, Jussi," },
+        { "code": "e", "value": "johtaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Tiensuu, Juha," },
+        { "code": "e", "value": "johtaja." }
+    ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Jääkäriprikaatin Jääkärikuoro," },
+        { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Lapin Sotilassoittokunta," },
+        { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "773", "ind1": "0", "ind2": " ", "subfields" : [
+        { "code": "7", "value": "nnjm" },
+        { "code": "t", "value": "Lauluja Lutolta ja Lapista. -" },
+        { "code": "d", "value": "[Kustannuspaikka tuntematon] : Luton Miesten Perinnetoimikunta, 2007. -" },
+        { "code": "h", "value": "1 CD-äänilevy. -" },
+        { "code": "o", "value": "Luton Miesten Perinnetoimikunta HMM1319-4. -" },
+        { "code": "g", "value": "Raita 7" }
+    ]},
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "c", "value": "881913" },
+        { "code": "b", "value": "viola" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-VIOLA" },
+        { "code": "b", "value": "20" },
+        { "code": "c", "value": "20190606" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "0950" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-ID" },
+        { "code": "b", "value": "00" },
+        { "code": "c", "value": "20190713" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "0007" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-ID" },
+        { "code": "b", "value": "00" },
+        { "code": "c", "value": "20190831" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "0114" }
+    ]},
+    { "tag": "CAT", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "LOAD-FIX" },
+        { "code": "b", "value": "30" },
+        { "code": "c", "value": "20200806" },
+        { "code": "l", "value": "FIN01" },
+        { "code": "h", "value": "1520" }
+    ]},
+    { "tag": "LOW", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "VIOLA" }
+    ]},
+    { "tag": "LOW", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "FIKKA" }
+    ]}
+  ]
+}

--- a/test-fixtures/collectRecordValues/15/metadata.json
+++ b/test-fixtures/collectRecordValues/15/metadata.json
@@ -1,0 +1,5 @@
+{
+    "description": "Should handle monographic component part without 773 $w",
+    "skip": false,
+    "only": true
+}

--- a/test-fixtures/collectRecordValues/15/metadata.json
+++ b/test-fixtures/collectRecordValues/15/metadata.json
@@ -1,5 +1,5 @@
 {
     "description": "Should handle monographic component part without 773 $w",
     "skip": false,
-    "only": true
+    "only": false
 }

--- a/test-fixtures/compareRecordValues/773-no-source-prefix/expectedResults.json
+++ b/test-fixtures/compareRecordValues/773-no-source-prefix/expectedResults.json
@@ -1,0 +1,31 @@
+{
+  "commonIdentifiers": {
+    "deleted": false,
+    "standardIdentifiers": true,
+    "title": true
+  },
+  "000": {
+    "bibliographicLevel": true,
+    "encodingLevel": true,
+    "typeOfRecord": true
+  },
+  "001": {
+    "isMelindaId": true,
+    "value": true
+  },
+  "005": true,
+  "042": true,
+  "245": {
+    "nameOfPartInSectionOfAWork": "undefined",
+    "numberOfPartInSectionOfAWork": "undefined",
+    "title": true
+  },
+  "title": true,
+  "336": true,
+  "337": true,
+  "338": true,
+  "773": true,
+  "CAT": true,
+  "LOW": true,
+  "SID": true
+}

--- a/test-fixtures/compareRecordValues/773-no-source-prefix/inputRecordValuesA.json
+++ b/test-fixtures/compareRecordValues/773-no-source-prefix/inputRecordValuesA.json
@@ -1,0 +1,125 @@
+{
+  "245": {
+    "nameOfPartInSectionOfAWork": "undefined",
+    "numberOfPartInSectionOfAWork": "undefined",
+    "title": "773testi /"
+  },
+  "title": {
+    "f946Features": [],
+    "seriesFeatures": [],
+    "titleFeatures": {
+      "namesOfPartInSectionOfAWork": [],
+      "numbersOfPartInSectionOfAWork": [],
+      "remainderOfTitle": "undefined",
+      "title": "773testi /"
+    }
+  },
+  "336": {
+    "types": [
+      "txt"
+    ]
+  },
+  "337": {
+    "types": [
+      "n"
+    ]
+  },
+  "338": {
+    "types": [
+      "nc"
+    ]
+  },
+  "773": [
+    {
+      "enumerationAndFirstPage": "undefined",
+      "recordControlNumbers": [ "(FI-MELINDA)015633157" ]
+    }
+  ],
+  "000": {
+    "bibliographicLevel": {
+      "code": "m",
+      "level": "Monograph/Item"
+    },
+    "encodingLevel": {
+      "code": "4",
+      "level": "Core level"
+    },
+    "typeOfRecord": {
+      "code": "a",
+      "level": "Language material"
+    }
+  },
+  "001": {
+    "isMelindaId": true,
+    "value": "001590014"
+  },
+  "005": "2019-07-03T16:39:44+03:00",
+  "042": [],
+  "CAT": {
+    "latest": {
+      "cataloger": "LOAD-YSO",
+      "time": "2019-07-05T11:35:00+03:00"
+    },
+    "otherCats": [
+      {
+        "cataloger": "LOAD-YSO",
+        "time": "2019-07-03T16:39:00+03:00"
+      },
+      {
+        "cataloger": "LOAD-HELKA",
+        "time": "2018-05-03T23:28:00+03:00"
+      },
+      {
+        "cataloger": "LOAD-FIX",
+        "time": "2017-06-29T18:58:00+03:00"
+      },
+      {
+        "cataloger": "CONV-RDA",
+        "time": "2016-03-19T08:35:00+02:00"
+      },
+      {
+        "cataloger": "LOAD-FIX",
+        "time": "2014-12-31T10:18:00+02:00"
+      },
+      {
+        "cataloger": "undefined",
+        "time": "2009-05-29T17:40:00+03:00"
+      },
+      {
+        "cataloger": "CONV-ISBD",
+        "time": "2012-04-02T08:29:00+03:00"
+      }
+    ]
+  },
+  "LOW": [
+    "SELMA",
+    "JOSKU",
+    "HELKA",
+    "ALMA"
+  ],
+  "SID": [
+    {
+      "database": "helka",
+      "id": "772700"
+    },
+    {
+      "database": "alma",
+      "id": "225753"
+    },
+    {
+      "database": "josku",
+      "id": "271085"
+    },
+    {
+      "database": "selma",
+      "id": "197324"
+    }
+  ],
+  "commonIdentifiers": {
+    "deleted": false,
+    "standardIdentifiers": [
+      "90-6779-080-X"
+    ],
+    "title": "European citizenship"
+  }
+}

--- a/test-fixtures/compareRecordValues/773-no-source-prefix/inputRecordValuesA.json
+++ b/test-fixtures/compareRecordValues/773-no-source-prefix/inputRecordValuesA.json
@@ -32,7 +32,7 @@
   "773": [
     {
       "enumerationAndFirstPage": "undefined",
-      "recordControlNumbers": [ "(FI-MELINDA)015633157" ]
+      "recordControlNumbers": []
     }
   ],
   "000": {

--- a/test-fixtures/compareRecordValues/773-no-source-prefix/inputRecordValuesB.json
+++ b/test-fixtures/compareRecordValues/773-no-source-prefix/inputRecordValuesB.json
@@ -1,0 +1,126 @@
+{
+  "245": {
+    "nameOfPartInSectionOfAWork": "undefined",
+    "numberOfPartInSectionOfAWork": "undefined",
+    "title": "773testi /"
+  },
+  "title": {
+    "f946Features": [],
+    "seriesFeatures": [],
+    "titleFeatures": {
+      "namesOfPartInSectionOfAWork": [],
+      "numbersOfPartInSectionOfAWork": [],
+      "remainderOfTitle": "undefined",
+      "title": "773testi /"
+    }
+  },
+  "336": {
+    "types": [
+      "txt"
+    ]
+  },
+  "337": {
+    "types": [
+      "n"
+    ]
+  },
+  "338": {
+    "types": [
+      "nc"
+    ]
+  },
+  "773": [
+    {
+      "enumerationAndFirstPage": "undefined",
+      "recordControlNumbers": [ "(FI-MELINDA)015633157" ],
+      "relatedParts": "Raita 9"
+    }
+  ],
+  "000": {
+    "bibliographicLevel": {
+      "code": "m",
+      "level": "Monograph/Item"
+    },
+    "encodingLevel": {
+      "code": "4",
+      "level": "Core level"
+    },
+    "typeOfRecord": {
+      "code": "a",
+      "level": "Language material"
+    }
+  },
+  "001": {
+    "isMelindaId": true,
+    "value": "001590014"
+  },
+  "005": "2019-07-03T16:39:44+03:00",
+  "042": [],
+  "CAT": {
+    "latest": {
+      "cataloger": "LOAD-YSO",
+      "time": "2019-07-05T11:35:00+03:00"
+    },
+    "otherCats": [
+      {
+        "cataloger": "LOAD-YSO",
+        "time": "2019-07-03T16:39:00+03:00"
+      },
+      {
+        "cataloger": "LOAD-HELKA",
+        "time": "2018-05-03T23:28:00+03:00"
+      },
+      {
+        "cataloger": "LOAD-FIX",
+        "time": "2017-06-29T18:58:00+03:00"
+      },
+      {
+        "cataloger": "CONV-RDA",
+        "time": "2016-03-19T08:35:00+02:00"
+      },
+      {
+        "cataloger": "LOAD-FIX",
+        "time": "2014-12-31T10:18:00+02:00"
+      },
+      {
+        "cataloger": "undefined",
+        "time": "2009-05-29T17:40:00+03:00"
+      },
+      {
+        "cataloger": "CONV-ISBD",
+        "time": "2012-04-02T08:29:00+03:00"
+      }
+    ]
+  },
+  "LOW": [
+    "SELMA",
+    "JOSKU",
+    "HELKA",
+    "ALMA"
+  ],
+  "SID": [
+    {
+      "database": "helka",
+      "id": "772700"
+    },
+    {
+      "database": "alma",
+      "id": "225753"
+    },
+    {
+      "database": "josku",
+      "id": "271085"
+    },
+    {
+      "database": "selma",
+      "id": "197324"
+    }
+  ],
+  "commonIdentifiers": {
+    "deleted": false,
+    "standardIdentifiers": [
+      "90-6779-080-X"
+    ],
+    "title": "European citizenship"
+  }
+}

--- a/test-fixtures/compareRecordValues/773-no-source-prefix/metadata.json
+++ b/test-fixtures/compareRecordValues/773-no-source-prefix/metadata.json
@@ -1,5 +1,5 @@
 {
     "description": "CREATE TEST: Compare test: 773 without source-prefix",
-    "skip": true,
-    "only": true
+    "skip": false,
+    "only": false
 }

--- a/test-fixtures/compareRecordValues/773-no-source-prefix/metadata.json
+++ b/test-fixtures/compareRecordValues/773-no-source-prefix/metadata.json
@@ -1,0 +1,5 @@
+{
+    "description": "CREATE TEST: Compare test: 773 without source-prefix",
+    "skip": true,
+    "only": true
+}

--- a/test-fixtures/compareRecordValues/773-no-source-prefix/metadata.json
+++ b/test-fixtures/compareRecordValues/773-no-source-prefix/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "CREATE TEST: Compare test: 773 without source-prefix",
+    "description": "Compare test: 773 $w without source-prefix",
     "skip": false,
     "only": false
 }


### PR DESCRIPTION
Do not crash if a record has f773/f973 that does not have a subfield $w or only has subfield $w:s with record control numbers without source prefixes.